### PR TITLE
Use theme accent for bar icon while playing

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -59,6 +59,7 @@ BarWidget {
     text: root.displayText
     fontSize: root.iconOnly ? Style.font.bodySmall : Style.font.body
     active: root.spotify && root.spotify.playing
+    activeColor: Color.accent
     tooltipText: root.spotify && root.spotify.hasMedia
       ? root.spotify.title + (root.spotify.artist ? " — " + root.spotify.artist : "")
       : "Omarchy Spotify"


### PR DESCRIPTION
Active bar widget defaulted to bar.urgent (alarm red on themes like Osaka Jade) during playback. Override with activeColor: Color.accent so the icon follows the theme accent. 

<img width="434" height="34" alt="example" src="https://github.com/user-attachments/assets/8521576a-ae10-4d2c-a25e-228bf8f88c16" />
