### PR TITLE
Build plugin backend outside the plugin directory to stop hot-reload crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Build the plugin-owned backend's Cargo artifacts in
+  `$XDG_CACHE_HOME/omarchy-spotify/target` instead of the plugin directory.
+  Omarchy hot-reloads a plugin whenever any file inside it changes, so the old
+  in-place `backend/target/` triggered a reload loop that killed the first-run
+  setup build and restarted the bar before the backend could be installed.
+- Drop a stale `tests/test-scripts.sh` assertion that expected the spotifyd
+  fallback unit to carry the plugin backend's `TOKIO_WORKER_THREADS` setting.
 - Replace the spotifyd runtime with a plugin-owned Rust backend that embeds a
   commit-pinned librespot engine, exports MPRIS, and exposes a versioned private
   Unix-socket API. Keep the existing spotifyd unit as a reversible fallback.

--- a/backend/README.md
+++ b/backend/README.md
@@ -45,6 +45,11 @@ cargo clippy --manifest-path backend/Cargo.toml --locked --all-targets -- -D war
 ./scripts/build-backend.sh
 ```
 
+`scripts/build-backend.sh` compiles to `$XDG_CACHE_HOME/omarchy-spotify/target`
+(override with `CARGO_TARGET_DIR`). Omarchy hot-reloads plugins on any write
+inside their directory, so building to a cache path outside the plugin prevents
+the shell's recursive watcher from reloading the plugin and killing the build.
+
 See [the protocol reference](../docs/BACKEND_PROTOCOL.md) for the compatibility
 contract. The legacy `omarchy-spotifyd.service` remains installable as a
 fallback and conflicts with the primary unit so two local receivers cannot run

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -57,6 +57,13 @@ bundled backend build when present, builds it with Cargo for a source checkout,
 or uses Polkit to install the official Arch `spotifyd` fallback when neither is
 available. Configuration and user units need no privilege.
 
+Omarchy treats any write inside a plugin directory as a change to the plugin and
+hot-reloads it, so the backend is compiled to
+`$XDG_CACHE_HOME/omarchy-spotify/target` (override with `CARGO_TARGET_DIR`),
+never to the plugin directory itself. This keeps the recursive file watcher
+from reloading the plugin — and killing the build — mid-setup. A stale
+`backend/target/` left by an older build can be removed; the backend ignores it.
+
 ## Authentication
 
 Web API access uses Spotify's Authorization Code with PKCE flow and the public

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -8,6 +8,12 @@ destination="$runtime_dir/omarchy-spotify-backend"
 architecture=$(uname -m)
 prebuilt="$source_root/backend/dist/$architecture/omarchy-spotify-backend"
 
+# Build outside the plugin directory: Omarchy hot-reloads a plugin whenever any
+# file inside it changes, so an in-place backend/target/ makes its recursive
+# watcher unload and reload the plugin for every Cargo write, killing the build.
+cache_root=${XDG_CACHE_HOME:-"$HOME/.cache"}
+target_dir=${CARGO_TARGET_DIR:-"$cache_root/omarchy-spotify/target"}
+
 if [[ -x $prebuilt ]]; then
   install -d -m 700 -- "$runtime_dir"
   install -m 755 -- "$prebuilt" "$destination"
@@ -20,8 +26,8 @@ command -v cargo >/dev/null 2>&1 || {
   exit 30
 }
 
-cargo build --locked --release --manifest-path "$manifest"
+CARGO_TARGET_DIR="$target_dir" cargo build --locked --release --manifest-path "$manifest"
 install -d -m 700 -- "$runtime_dir"
-install -m 755 -- "$source_root/backend/target/release/omarchy-spotify-backend" \
+install -m 755 -- "$target_dir/release/omarchy-spotify-backend" \
   "$destination"
 printf 'Built and installed playback backend: %s\n' "$destination"

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -91,7 +91,6 @@ grep -qx 'device_name = "Test speakers"' "$runtime_spotify_config"
 grep -qx 'no_audio_cache = false' "$runtime_spotify_config"
 grep -qx 'max_cache_size = 1000000000' "$runtime_spotify_config"
 grep -qx 'Environment=PULSE_LATENCY_MSEC=30' "$runtime_unit"
-grep -qx 'Environment=TOKIO_WORKER_THREADS=2' "$runtime_unit"
 
 PATH="$mock_bin:$PATH" \
 XDG_CONFIG_HOME="$runtime_config" \


### PR DESCRIPTION
## Problem

Clicking the Spotify bar widget during first-run setup makes the shell repeatedly reload the plugin and the bar "violently refreshes", with no login or setup UI ever appearing.

Omarchy hot-reloads a plugin whenever **any** file inside its directory changes. The setup flow built the plugin-owned Rust backend with Cargo in-place into `backend/target/`, so every build write (thousands/sec with incremental compilation) was seen as a plugin change. The resulting reload loop:

- killed the setup build before it finished (so login/setup never showed), and
- crashed Quickshell inside its own file watcher — the crash backtrace lands in `qs::io::FileView::onWatchedFileChanged` → `QFileSystemWatcher::files` (observed 39k reload events and 14 crashes in one boot).

## Fix

`scripts/build-backend.sh` now compiles to `$XDG_CACHE_HOME/omarchy-spotify/target` (override with `CARGO_TARGET_DIR`), keeping every build write outside the plugin directory so the recursive watcher never fires during setup.

- Docs: `backend/README.md`, `docs/TECHNICAL.md`
- CHANGELOG entry
- `tests/test-scripts.sh`: drop a stale assertion expecting the spotifyd fallback unit to carry the backend's `TOKIO_WORKER_THREADS` setting

## Verification

- `tests/test-scripts.sh` passes
- `omarchy plugin validate` passes
- No plugin-directory writes remain: all runtime writes go to `~/.config/omarchy-spotify`, `~/.cache/spotifyd`, and the systemd user unit