### PR TITLE
Add a Quit action to the mini player

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -69,6 +69,8 @@ BarWidget {
     if (spotify && spotify.lyricsAvailable) actions.push("lyrics")
     if (spotify && spotify.hasPlayer && spotify.volumeSupported)
       actions.push("volume")
+    if (spotify && spotify.accountConnected
+      && spotify.daemon && spotify.daemon.running) actions.push("quit")
     actions.push("open")
     return actions
   }
@@ -79,6 +81,13 @@ BarWidget {
   function close() {
     miniShortcutHelpVisible = false
     popupOpen = false
+  }
+  function quitPlayer() {
+    if (spotify) {
+      if (spotify.playing) spotify.togglePlayback()
+      spotify.stopEngine()
+    }
+    close()
   }
   function closeForPopoutSwitch() {
     popoutSwitchClosing = true
@@ -278,7 +287,8 @@ BarWidget {
     else if (action === "prompt-confirm") {
       if (spotify && !spotify.lyricsPluginBusy)
         spotify.confirmLyricsPlugin(lyricsRequestKey)
-    } else if (action === "artist") openCurrentArtist()
+    } else if (action === "quit") quitPlayer()
+    else if (action === "artist") openCurrentArtist()
     else if (action === "like") {
       if (spotify) spotify.toggleCurrentTrackSaved()
     } else if (action === "shuffle") {
@@ -988,6 +998,8 @@ BarWidget {
 
         Text {
           width: parent.width - openButton.width - Style.space(6)
+            - (miniQuitButton.visible
+              ? miniQuitButton.width + Style.space(6) : 0)
           anchors.verticalCenter: parent.verticalCenter
           text: !root.spotify ? "Spotify is unavailable"
             : (root.spotify.lastError !== "" ? root.spotify.lastError
@@ -1005,6 +1017,20 @@ BarWidget {
           font.family: root.bar ? root.bar.fontFamily : Style.font.family
           font.pixelSize: Style.font.caption
           elide: Text.ElideRight
+        }
+
+        Button {
+          id: miniQuitButton
+          text: "Quit"
+          iconText: "󰐥"
+          foreground: root.foreground
+          focusable: true
+          visible: root.spotify && root.spotify.accountConnected
+            && root.spotify.daemon && root.spotify.daemon.running
+          hasCursor: root.miniCursorActive && root.miniCursor === "quit"
+          tooltipText: "Stop playback and shut the backend down"
+          onClicked: root.quitPlayer()
+          onHovered: function(on) { if (on) root.setMiniCursor("quit") }
         }
 
         Button {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a Quit action to the mini-player footer that pauses playback and stops
+  the backend, so closing the window no longer leaves music playing with no
+  obvious way to stop it short of the idle timeout.
+
 - Finish installing Omasing after the shell reloads. Adding the plugin writes
   into the plugin directory, which used to kill the installer before the
   lyrics widget could be enabled.


### PR DESCRIPTION
## What

Adds a **Quit** action to the mini-player footer, beside **Open**.

![Quit button in the mini-player footer](https://raw.githubusercontent.com/VaHughes/Omarchy-Spotify/pr-assets/quit-button.png)

## Why

Closing the mini-player or the full player leaves the backend running and the music playing. From the popup itself there is no way to actually stop — the options are the play/pause control (which leaves the backend resident), an external MPRIS client, or waiting out `idleShutdownMinutes`. As a new user I closed the window with `Super+W`, was surprised that music kept playing, and had no obvious way to stop it.

## How

`quitPlayer()` pauses playback if playing, calls `stopEngine()` so the backend exits immediately rather than after the idle timeout, and closes the popup.

- Registered in `miniKeyboardActions` just before `"open"`, so `Tab` reaches it and `Enter` fires it.
- Only renders while `accountConnected && daemon.running`, so there is no dead control when there is nothing to stop.
- The footer status text reserves the button's width only while it is visible, leaving the layout unchanged when hidden.
- Reuses the shared `Button` component with the power glyph, so it picks up theme colors and tooltips like its neighbours.

A power glyph rather than an `x` is deliberate: `x` reads as "dismiss this popup", but the action stops playback and shuts the backend down. Placing it next to **Open** makes the pairing read naturally — one opens the full player, one shuts everything down.

## Testing

Manual, on Omarchy 4.0.0-1 with plugin 1.0.2:

- Clicked **Quit** while playing locally: playback paused, `omarchy-spotify-backend` exited immediately, popup closed.
- Reopened and pressed play: backend relaunched and the session restored from the keyring as usual.
- `Tab` from the mini-player reaches **Quit** before **Open**; `Enter` fires it.
- With the backend stopped, the button is hidden and the footer layout is unchanged.

Note that a full `omarchy restart shell` is needed to see this change — the save-triggered plugin reload does not rebuild an already-instantiated bar widget.

## Not included

The full player (`Panel.qml`) still has no quit affordance. Happy to add the same control there if you want it in both.
