### PR TITLE
Expose Spotify volume controls over shell IPC

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -183,13 +183,11 @@ BarWidget {
     }
 
     function volumeUp(): string {
-      root.adjustVolume(0.05)
-      return "ok"
+      return root.adjustVolume(0.05) ? "ok" : "unavailable"
     }
 
     function volumeDown(): string {
-      root.adjustVolume(-0.05)
-      return "ok"
+      return root.adjustVolume(-0.05) ? "ok" : "unavailable"
     }
   }
 
@@ -267,10 +265,11 @@ BarWidget {
   }
 
   function adjustVolume(delta) {
-    if (!spotify || !spotify.volumeSupported) return
+    if (!spotify || !spotify.volumeSupported) return false
     var next = Api.nextVolume(spotify.volume, delta)
     if (Api.shouldRememberVolume(next)) volumeBeforeMute = next
     spotify.setVolume(next)
+    return true
   }
 
   function toggleMute() {

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -181,6 +181,16 @@ BarWidget {
     function toggleFullPlayer(): string {
       return root.toggleFullPlayerShortcut()
     }
+
+    function volumeUp(): string {
+      root.adjustVolume(0.05)
+      return "ok"
+    }
+
+    function volumeDown(): string {
+      root.adjustVolume(-0.05)
+      return "ok"
+    }
   }
 
   function openCurrentArtist() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Change Spotify volume from a keybinding with `volumeUp` and `volumeDown` on
+  `quickshell.spotify.player`, 5% per call, without opening the player. The
+  commands return `unavailable` when volume cannot be changed.
+
 - Finish installing Omasing after the shell reloads. Adding the plugin writes
   into the plugin directory, which used to kill the installer before the
   lyrics widget could be enabled.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ omarchy plugin add https://github.com/stappmus/Omarchy-Spotify.git --enable
 In Omarchy Spotify's Settings, choose whether **Super+Shift+M** launches
 Omarchy's Music app, toggles the full player, or toggles the mini-player.
 
+Raise or lower Spotify volume from a keybinding without opening the player:
+
+```bash
+omarchy shell -q quickshell.spotify.player volumeUp
+omarchy shell -q quickshell.spotify.player volumeDown
+```
+
+Each step is 5%, the same as Ctrl+Up / Ctrl+Down. This changes Spotify's own
+volume, including speakers, not the computer's output level.
+
 Click the Spotify icon on the left side of the bar. The mini-player asks you
 to **Set up and continue**, then Spotify sign-in finishes in your browser. You
 can move the widget later with Omarchy's bar controls.


### PR DESCRIPTION
Spotify already has volume controls in the mini-player, but there isn't a way for another shell component to trigger them.

This adds `volumeUp` and `volumeDown` to the existing `quickshell.spotify.player` IPC target. Each changes Spotify volume by 5%, so Hyprland bindings can control Spotify without opening the player.

`scripts/test.sh` passes: 105 QML tests, 13 Python tests, plugin validation, `qmllint`, Cargo formatting, tests, and Clippy.
