### PR TITLE
Fix bar label clipping and make the bar text width adjustable

### DIFF
--- a/Api.js
+++ b/Api.js
@@ -129,6 +129,34 @@ function canScrollBarText(showTitle, showArtist) {
   return showTitle === true || showArtist === true
 }
 
+var BAR_TEXT_WIDTH_MIN = 160
+var BAR_TEXT_WIDTH_MAX = 560
+var BAR_TEXT_WIDTH_STEP = 40
+
+// Slider geometry for the bar label cap. The uncapped notch sits one step past
+// the widest real width, so 0 has somewhere to live without a second control.
+function barTextWidthSlider() {
+  return {
+    min: BAR_TEXT_WIDTH_MIN,
+    step: BAR_TEXT_WIDTH_STEP,
+    unlimited: BAR_TEXT_WIDTH_MAX + BAR_TEXT_WIDTH_STEP,
+    ticks: (BAR_TEXT_WIDTH_MAX - BAR_TEXT_WIDTH_MIN) / BAR_TEXT_WIDTH_STEP + 2
+  }
+}
+
+// Cap in unscaled px, snapped to the slider's notches. 0 means no cap;
+// anything unparseable falls back to the historical 240px bound.
+function normalizedMaxBarTextWidth(value) {
+  if (value === undefined || value === null || String(value).trim() === "")
+    return 240
+  var width = Number(value)
+  if (!isFinite(width) || width < 0) return 240
+  if (width === 0) return 0
+  var clamped = Math.max(BAR_TEXT_WIDTH_MIN, Math.min(BAR_TEXT_WIDTH_MAX, width))
+  return BAR_TEXT_WIDTH_MIN + Math.round(
+    (clamped - BAR_TEXT_WIDTH_MIN) / BAR_TEXT_WIDTH_STEP) * BAR_TEXT_WIDTH_STEP
+}
+
 function normalizedScrollSpeed(value) {
   var speed = Number(value)
   if (!isFinite(speed)) speed = 1

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -459,10 +459,20 @@ BarWidget {
       ? root.spotify.title + (root.spotify.artist ? " — " + root.spotify.artist : "")
       : (root.spotify && !root.spotify.accountConnected
         ? "Set up Omarchy Spotify" : "Omarchy Spotify")
+    // Reserve everything scrollClip subtracts back out — glyph, Row spacing and
+    // both button margins. Style.space(24) covered about a pixel of that, so the
+    // label sat ~23px short of its own advanceWidth: needsScroll stayed true and
+    // the fade mask clipped titles that had room to render.
+    readonly property real barTextSlot: glyphMetrics.advanceWidth
+      + labelMetrics.advanceWidth + barContent.spacing
+      + button.scaledHorizontalMargin * 2 + Style.space(10)
+    readonly property real barTextCap: root.spotify ? root.spotify.maxBarTextWidth : 240
+
     fixedWidth: root.vertical ? root.barSize
       : (root.iconOnly ? Style.bar.statusSlot
-        : Math.min(Style.space(240), Math.max(root.barSize,
-          glyphMetrics.advanceWidth + labelMetrics.advanceWidth + Style.space(24))))
+        : Math.max(root.barSize, barTextCap > 0
+          ? Math.min(Style.space(barTextCap), barTextSlot)
+          : barTextSlot))
     fixedHeight: root.vertical && root.iconOnly ? Style.bar.statusSlot : -1
     clip: true
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -50,6 +50,10 @@ Item {
   property bool draftShowArtist: false
   property bool draftScrollBarText: false
   property real draftScrollSpeed: 1
+  // 0 means no cap — the slot grows with the track text.
+  property real draftMaxBarTextWidth: 240
+  // Disclosure state for the width slider; deliberately not persisted.
+  property bool barTextWidthExpanded: false
   property string draftAudioQuality: "320 kbps"
   property var contextItem: null
   property var contextSourceItems: []
@@ -107,6 +111,7 @@ Item {
     draftShowArtist = service.showArtistName
     draftScrollBarText = service.scrollBarText
     draftScrollSpeed = service.scrollSpeed
+    draftMaxBarTextWidth = service.maxBarTextWidth
     draftAudioQuality = service.audioQuality
   }
 
@@ -122,6 +127,7 @@ Item {
       showArtistName: draftShowArtist ? "On" : "Off",
       scrollBarText: draftScrollBarText ? "On" : "Off",
       scrollSpeed: Api.normalizedScrollSpeed(draftScrollSpeed),
+      maxBarTextWidth: Api.normalizedMaxBarTextWidth(draftMaxBarTextWidth),
       audioQuality: draftAudioQuality
     }
     service.persistSettings(values)
@@ -158,7 +164,26 @@ Item {
     return value.toFixed(2).replace(/\.00$/, "").replace(/0$/, "") + "×"
   }
 
+  readonly property var barTextWidthSlider: Api.barTextWidthSlider()
+  readonly property bool barTextWidthUnlimited:
+    Api.normalizedMaxBarTextWidth(draftMaxBarTextWidth) === 0
+
+  function maxBarTextWidthLabel() {
+    var value = Api.normalizedMaxBarTextWidth(draftMaxBarTextWidth)
+    return value === 0 ? "Unlimited" : Math.round(value) + " px"
+  }
+  function maxBarTextWidthSliderValue() {
+    var value = Api.normalizedMaxBarTextWidth(draftMaxBarTextWidth)
+    return value === 0 ? barTextWidthSlider.unlimited : value
+  }
+  function setMaxBarTextWidthFromSlider(value) {
+    draftMaxBarTextWidth = value >= barTextWidthSlider.unlimited
+      ? 0 : Api.normalizedMaxBarTextWidth(value)
+    enforceScrollAvailability()
+  }
+
   function enforceScrollAvailability() {
+    if (barTextWidthUnlimited) draftScrollBarText = false
     if (!Api.canScrollBarText(draftShowTitle, draftShowArtist))
       draftScrollBarText = false
   }
@@ -4601,11 +4626,24 @@ Item {
                   foreground: root.foreground
                   selected: root.draftScrollBarText
                   enabled: Api.canScrollBarText(root.draftShowTitle, root.draftShowArtist)
-                  tooltipText: "Scroll bar text only when it is too wide to fit"
+                    && !root.barTextWidthUnlimited
+                  tooltipText: root.barTextWidthUnlimited
+                    ? "Unavailable while the bar width is unlimited — the label always fits"
+                    : "Scroll bar text only when it is too wide to fit"
                   onClicked: {
                     root.draftScrollBarText = !root.draftScrollBarText
                     root.persistDraftSettings()
                   }
+                }
+                // Discloses the width slider rather than changing a setting;
+                // the selected highlight marks the open state.
+                Button {
+                  text: "Width · " + root.maxBarTextWidthLabel()
+                  foreground: root.foreground
+                  selected: root.barTextWidthExpanded
+                  enabled: Api.canScrollBarText(root.draftShowTitle, root.draftShowArtist)
+                  tooltipText: "How wide the bar label may grow"
+                  onClicked: root.barTextWidthExpanded = !root.barTextWidthExpanded
                 }
               }
 
@@ -4656,6 +4694,66 @@ Item {
                     root.draftScrollSpeed = Api.normalizedScrollSpeed(value)
                     root.persistDraftSettings()
                   }
+                }
+              }
+
+              Column {
+                width: parent.width
+                spacing: Style.space(4)
+                visible: Api.canScrollBarText(root.draftShowTitle, root.draftShowArtist)
+                  && root.barTextWidthExpanded
+
+                Row {
+                  width: parent.width
+
+                  Text {
+                    id: maxBarWidthTitle
+                    text: "MAX WIDTH"
+                    color: Qt.darker(root.foreground, 1.4)
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                    font.bold: true
+                  }
+                  Item {
+                    width: Math.max(0, parent.width - maxBarWidthTitle.implicitWidth
+                      - maxBarWidthValue.implicitWidth)
+                    height: 1
+                  }
+                  Text {
+                    id: maxBarWidthValue
+                    text: root.maxBarTextWidthLabel()
+                    color: root.foreground
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.bodySmall
+                    font.bold: true
+                  }
+                }
+
+                PanelSlider {
+                  width: parent.width
+                  bar: root.panelBar
+                  minimum: root.barTextWidthSlider.min
+                  maximum: root.barTextWidthSlider.unlimited
+                  step: root.barTextWidthSlider.step
+                  tickCount: root.barTextWidthSlider.ticks
+                  value: root.maxBarTextWidthSliderValue()
+                  onMoved: function(value) {
+                    root.setMaxBarTextWidthFromSlider(value)
+                  }
+                  onReleased: function(value) {
+                    root.setMaxBarTextWidthFromSlider(value)
+                    root.persistDraftSettings()
+                  }
+                }
+
+                Text {
+                  width: parent.width
+                  visible: root.barTextWidthUnlimited
+                  text: "Very long titles will take space from other bar widgets."
+                  color: Qt.darker(root.foreground, 1.45)
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  wrapMode: Text.WordWrap
                 }
               }
 

--- a/Service.qml
+++ b/Service.qml
@@ -33,6 +33,7 @@ Item {
     showArtistName: "Off",
     scrollBarText: "Off",
     scrollSpeed: "1",
+    maxBarTextWidth: "240",
     audioQuality: "320 kbps",
     searchHistory: "[]",
     sessionState: "{}"
@@ -49,6 +50,9 @@ Item {
   readonly property bool showArtistName: String(settings.showArtistName || "Off") === "On"
   readonly property bool scrollBarText: String(settings.scrollBarText || "Off") === "On"
   readonly property real scrollSpeed: Api.normalizedScrollSpeed(settings.scrollSpeed)
+  // Bar label cap in unscaled px; 0 means no cap.
+  readonly property real maxBarTextWidth: Api.normalizedMaxBarTextWidth(
+    settings.maxBarTextWidth)
   readonly property int bitrateKbps: {
     var quality = String(settings.audioQuality || "320 kbps")
     return quality.indexOf("96") === 0 ? 96
@@ -411,7 +415,7 @@ Item {
     var source = values || {}
     var keys = ["deviceName", "idleShutdownMinutes", "showMiniPlayer",
       "shortcutPlayer", "showTrackTitle", "showArtistName", "scrollBarText",
-      "scrollSpeed", "audioQuality"]
+      "scrollSpeed", "maxBarTextWidth", "audioQuality"]
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i]
       if (source[key] !== undefined) next[key] = source[key]
@@ -436,6 +440,9 @@ Item {
     if (!Api.canScrollBarText(next.showTrackTitle === "On", next.showArtistName === "On"))
       next.scrollBarText = "Off"
     next.scrollSpeed = String(Api.normalizedScrollSpeed(next.scrollSpeed))
+    next.maxBarTextWidth = String(Api.normalizedMaxBarTextWidth(next.maxBarTextWidth))
+    // An uncapped slot always fits its text, so the marquee could never run.
+    if (Number(next.maxBarTextWidth) === 0) next.scrollBarText = "Off"
     var quality = String(next.audioQuality || "320 kbps")
     next.audioQuality = quality.indexOf("96") === 0 ? "96 kbps"
       : (quality.indexOf("160") === 0 ? "160 kbps" : "320 kbps")

--- a/tests/tst_api.qml
+++ b/tests/tst_api.qml
@@ -32,6 +32,36 @@ TestCase {
     verify(!Api.canScrollBarText(false, false))
   }
 
+  function test_normalizedMaxBarTextWidth_defaultsClampsAndSnaps() {
+    compare(Api.normalizedMaxBarTextWidth(undefined), 240)
+    compare(Api.normalizedMaxBarTextWidth(null), 240)
+    compare(Api.normalizedMaxBarTextWidth(""), 240)
+    compare(Api.normalizedMaxBarTextWidth("nonsense"), 240)
+    compare(Api.normalizedMaxBarTextWidth(-40), 240)
+    // 0 is the uncapped sentinel and must survive normalization untouched.
+    compare(Api.normalizedMaxBarTextWidth(0), 0)
+    compare(Api.normalizedMaxBarTextWidth("0"), 0)
+    compare(Api.normalizedMaxBarTextWidth(240), 240)
+    compare(Api.normalizedMaxBarTextWidth(247), 240)
+    compare(Api.normalizedMaxBarTextWidth(265), 280)
+    compare(Api.normalizedMaxBarTextWidth(10), 160)
+    compare(Api.normalizedMaxBarTextWidth(9999), 560)
+  }
+
+  function test_barTextWidthSlider_notchesCoverEveryNormalizedWidth() {
+    var slider = Api.barTextWidthSlider()
+    // The uncapped notch must sit past every real width, so no stored value can
+    // normalize onto it and be mistaken for "unlimited".
+    for (var i = 0; i < slider.ticks; i++) {
+      var stop = slider.min + i * slider.step
+      if (stop === slider.unlimited) continue
+      compare(Api.normalizedMaxBarTextWidth(stop), stop)
+    }
+    compare(slider.min + (slider.ticks - 1) * slider.step, slider.unlimited)
+    verify(Api.normalizedMaxBarTextWidth(slider.unlimited) < slider.unlimited)
+    compare(Api.normalizedMaxBarTextWidth(240), 240)
+  }
+
   function test_normalizedScrollSpeed_defaultsClampsAndSnaps() {
     compare(Api.normalizedScrollSpeed(undefined), 1)
     compare(Api.normalizedScrollSpeed("not-a-speed"), 1)


### PR DESCRIPTION
## Problem

Long track titles are clipped by the fade mask even when the bar slot has room.

`fixedWidth` reserves `Style.space(24)` around the text, but `scrollClip.width`
subtracts the glyph, `barContent.spacing` (6), and `scaledHorizontalMargin * 2`
(~17) back out — about 23px at the default text size. That leaves the label
roughly one pixel of headroom, so `labelMetrics.advanceWidth > scrollClip.width`
is essentially always true, `needsScroll` latches on, and the mask trims the
tail of titles that would otherwise fit.

Raising the 240px cap alone does not help — the same ~23px shortfall reappears
at the new width.

## Changes

1. **Fix the padding.** Reserve the parts `scrollClip` removes (glyph, Row
   spacing, both margins), plus `Style.space(10)` for the glyph's
   advanceWidth/implicitWidth difference. Text now fills the slot it is given.

2. **Make the bound configurable.** `maxBarTextWidth` replaces the hardcoded
   `Style.space(240)`, surfaced in Settings → BAR TEXT as a `Width · 240 px`
   button beside the existing toggles. Clicking it discloses a MAX WIDTH slider
   built to match SCROLL SPEED: the same 12 notches, 160–560px in 40px steps,
   with a final notch for **Unlimited** where the slot grows to fit the title.

`Api.barTextWidthSlider()` derives the slider's geometry from the same three
constants the normalizer snaps to, so the notches and the stored values cannot
drift apart.

### Behaviour notes

- **Defaults are unchanged.** `maxBarTextWidth` starts at `240` — the previous
  bound — which lands on the slider's third notch. An untouched install renders
  identically.
- The button discloses rather than toggles, so its expanded state is not
  persisted and the selected highlight marks it.
- **Unlimited disables Scroll overflow.** An uncapped slot always fits its text,
  so the marquee could never run; leaving the toggle live would let it claim to
  be On while doing nothing. This mirrors how a missing title/artist already
  forces it off via `enforceScrollAvailability`.

## Testing

`tests/tst_api.qml` gains coverage for `normalizedMaxBarTextWidth` (fallbacks,
the `0` sentinel, snapping, clamping) and for `barTextWidthSlider` — the latter
asserts every notch round-trips through the normalizer unchanged and that no
real width can normalize onto the Unlimited stop.

Full suite, `qmltestrunner` on Qt 6:

```
tst_api.qml            80 passed, 0 failed
tst_artist_links.qml    6 passed, 0 failed
tst_media_byline.qml    4 passed, 0 failed
tst_oauth.qml          11 passed, 0 failed
tst_scroll.qml          6 passed, 0 failed
```

Also exercised by hand on a 4-monitor Hyprland/Omarchy setup: default 240,
a mid value (360px), and Unlimited; at both 12px and 16px shell text size, since
the cap passes through `Style.space()`; and with the settings panel open and
closed. No QML warnings or binding loops on shell restart.
