### PR TITLE
Fix Spotify widget colors on transparent bar

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -553,8 +553,10 @@ BarWidget {
     hasVisualContent: true
     fontSize: root.iconOnly ? Style.font.bodySmall : Style.font.body
     active: root.spotify && root.spotify.playing
-    foreground: root.foreground
-    activeColor: root.foreground
+    // Follow the bar's contrast-aware color when transparency changes.
+    // Keep root.foreground theme-based for the popup/player surfaces.
+    foreground: root.bar ? root.bar.barForeground : root.foreground
+    activeColor: foreground
     tooltipText: root.spotify && root.spotify.hasMedia
       ? root.spotify.title + (root.spotify.artist ? " — " + root.spotify.artist : "")
       : (root.spotify && !root.spotify.accountConnected
@@ -620,7 +622,7 @@ BarWidget {
             id: barLabel
             anchors.verticalCenter: parent.verticalCenter
             text: root.barText
-            color: root.foreground
+            color: button.foreground
             font.family: root.bar ? root.bar.fontFamily : Style.font.family
             font.pixelSize: Style.font.body
             renderType: Text.NativeRendering


### PR DESCRIPTION
## Summary

- use the bar’s contrast-aware `barForeground` for the Spotify bar widget
- apply the same adaptive foreground to the scrolling track label
- keep the popup and full-player surfaces on the normal theme foreground

## Problem

When bar transparency was enabled, Omarchy recalculated widget text colors for contrast against the background. The Spotify icon and track title continued using the fixed theme foreground, so they became inconsistent with the other bar widgets and could have poor contrast.

## Verification

- toggled bar transparency and confirmed the Spotify icon and track title now follow the other bar widgets
- restarted Omarchy Shell and confirmed the corrected colors persist
- `PATH="/usr/lib/qt6/bin:$PATH" ./scripts/test.sh` passes
- QML tests: 119 passed, 0 failed
- Python tests: 14 passed
- script tests and plugin validation passed