### PR TITLE
Align Spotify controls with the Omarchy icon grid

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -544,14 +544,15 @@ BarWidget {
   Component.onCompleted: syncSettings()
   Component.onDestruction: if (spotify) spotify.setUiVisible(surfaceKey, false)
 
-  WidgetButton {
+  BarIconButton {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: ""
-    labelVisible: root.iconOnly
+    text: root.iconOnly ? "" : ""
     hasVisualContent: true
-    fontSize: root.iconOnly ? Style.font.bodySmall : Style.font.body
+    slotSize: Style.bar.iconSlot
+    opticalSize: Style.bar.iconCanvas
+    fontSize: root.iconOnly ? Style.bar.iconFont : Style.font.body
     active: root.spotify && root.spotify.playing
     // Follow the bar's contrast-aware color when transparency changes.
     // Keep root.foreground theme-based for the popup/player surfaces.
@@ -562,16 +563,16 @@ BarWidget {
       : (root.spotify && !root.spotify.accountConnected
         ? "Set up Omarchy Spotify" : "Omarchy Spotify")
     // Size from the painted glyph and label plus the real inner chrome.
-    readonly property real fittedWidth: Math.ceil(barGlyph.implicitWidth
+    readonly property real fittedWidth: Math.ceil(barGlyph.width
       + barContent.spacing + barLabel.implicitWidth + scaledHorizontalMargin * 2)
     readonly property real barTextCap: root.spotify ? root.spotify.maxBarTextWidth : 240
 
     fixedWidth: root.vertical ? root.barSize
-      : (root.iconOnly ? Style.bar.statusSlot
+      : (root.iconOnly ? Style.bar.iconSlot
         : Math.max(root.barSize, barTextCap > 0
           ? Math.min(Style.space(barTextCap), fittedWidth)
           : fittedWidth))
-    fixedHeight: root.vertical && root.iconOnly ? Style.bar.statusSlot : -1
+    fixedHeight: root.vertical && root.iconOnly ? Style.bar.iconSlot : -1
     clip: true
 
     Row {
@@ -581,21 +582,22 @@ BarWidget {
       visible: !root.iconOnly
       enabled: false
 
-      Text {
+      OpticalGlyph {
         id: barGlyph
         anchors.verticalCenter: parent.verticalCenter
+        width: Style.space(16)
+        height: Style.space(16)
         text: ""
         color: button.foreground
-        font.family: root.bar ? root.bar.fontFamily : Style.font.family
-        font.pixelSize: Style.font.body
-        renderType: Text.NativeRendering
+        fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+        fontSize: Style.font.body
       }
 
       Item {
         id: scrollClip
-        width: Math.max(0, button.width - barGlyph.implicitWidth
+        width: Math.max(0, button.width - barGlyph.width
           - barContent.spacing - button.scaledHorizontalMargin * 2)
-        height: barGlyph.implicitHeight
+        height: barGlyph.height
         anchors.verticalCenter: parent.verticalCenter
         clip: barLabel.needsScroll
 
@@ -1085,8 +1087,8 @@ BarWidget {
         visible: !root.lyricsInstallPromptVisible
           && (!root.spotify || root.spotify.accountConnected)
 
-        Button {
-          iconText: "󰒟"
+        TransportButton {
+          glyphText: "󰒟"
           foreground: root.foreground
           selected: root.spotify && root.spotify.shuffle
           hasCursor: root.miniCursorActive && root.miniCursor === "shuffle"
@@ -1097,8 +1099,8 @@ BarWidget {
           KeyHint { sequences: ["Ctrl+S"] }
         }
 
-        Button {
-          iconText: "󰒮"
+        TransportButton {
+          glyphText: "󰒮"
           foreground: root.foreground
           hasCursor: root.miniCursorActive && root.miniCursor === "previous"
           tooltipText: "Previous · Ctrl+Left"
@@ -1108,9 +1110,9 @@ BarWidget {
           KeyHint { sequences: ["Ctrl+Left"] }
         }
 
-        Button {
-          iconText: root.spotify && root.spotify.playing ? "󰏤" : "󰐊"
-          iconSize: Style.font.iconLarge
+        TransportButton {
+          glyphText: root.spotify && root.spotify.playing ? "󰏤" : "󰐊"
+          glyphSize: Style.font.iconLarge
           foreground: root.foreground
           selected: root.spotify && root.spotify.playing
           hasCursor: root.miniCursorActive && root.miniCursor === "play"
@@ -1122,8 +1124,8 @@ BarWidget {
           KeyHint { sequences: ["Space"] }
         }
 
-        Button {
-          iconText: "󰒭"
+        TransportButton {
+          glyphText: "󰒭"
           foreground: root.foreground
           hasCursor: root.miniCursorActive && root.miniCursor === "next"
           tooltipText: "Next · Ctrl+Right"
@@ -1133,8 +1135,8 @@ BarWidget {
           KeyHint { sequences: ["Ctrl+Right"] }
         }
 
-        Button {
-          iconText: root.spotify && root.spotify.repeatMode === "track" ? "󰑘" : "󰑖"
+        TransportButton {
+          glyphText: root.spotify && root.spotify.repeatMode === "track" ? "󰑘" : "󰑖"
           foreground: root.foreground
           selected: root.spotify && root.spotify.repeatMode !== "off"
           hasCursor: root.miniCursorActive && root.miniCursor === "repeat"
@@ -1146,8 +1148,8 @@ BarWidget {
           KeyHint { sequences: ["Ctrl+R"] }
         }
 
-        Button {
-          iconText: "󰎈"
+        TransportButton {
+          glyphText: "󰎈"
           foreground: root.foreground
           hasCursor: root.miniCursorActive && root.miniCursor === "lyrics"
           tooltipText: "Open lyrics in Omasing · Ctrl+Shift+L"

--- a/Panel.qml
+++ b/Panel.qml
@@ -4040,8 +4040,8 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 spacing: Style.space(3)
 
-                Button {
-                  iconText: "󰒟"
+                TransportButton {
+                  glyphText: "󰒟"
                   foreground: root.foreground
                   selected: root.service && root.service.shuffle
                   hasCursor: root.cursorOn("footer", "shuffle")
@@ -4053,8 +4053,8 @@ Item {
                   }
                   KeyHint { region: "footer"; action: "shuffle"; sequences: ["Ctrl+S"] }
                 }
-                Button {
-                  iconText: "󰒮"
+                TransportButton {
+                  glyphText: "󰒮"
                   foreground: root.foreground
                   hasCursor: root.cursorOn("footer", "previous")
                   tooltipText: root.shortcutHint("Previous", "Ctrl+Left")
@@ -4065,9 +4065,9 @@ Item {
                   }
                   KeyHint { region: "footer"; action: "previous"; sequences: ["Ctrl+Left"] }
                 }
-                Button {
-                  iconText: root.service && root.service.playing ? "󰏤" : "󰐊"
-                  iconSize: Style.font.iconLarge
+                TransportButton {
+                  glyphText: root.service && root.service.playing ? "󰏤" : "󰐊"
+                  glyphSize: Style.font.iconLarge
                   foreground: root.foreground
                   selected: root.service && root.service.playing
                   hasCursor: root.cursorOn("footer", "play")
@@ -4080,8 +4080,8 @@ Item {
                   }
                   KeyHint { region: "footer"; action: "play"; sequences: ["Space"] }
                 }
-                Button {
-                  iconText: "󰒭"
+                TransportButton {
+                  glyphText: "󰒭"
                   foreground: root.foreground
                   hasCursor: root.cursorOn("footer", "next")
                   tooltipText: root.shortcutHint("Next", "Ctrl+Right")
@@ -4092,8 +4092,8 @@ Item {
                   }
                   KeyHint { region: "footer"; action: "next"; sequences: ["Ctrl+Right"] }
                 }
-                Button {
-                  iconText: root.service && root.service.repeatMode === "track" ? "󰑘" : "󰑖"
+                TransportButton {
+                  glyphText: root.service && root.service.repeatMode === "track" ? "󰑘" : "󰑖"
                   foreground: root.foreground
                   selected: root.service && root.service.repeatMode !== "off"
                   hasCursor: root.cursorOn("footer", "repeat")
@@ -4107,8 +4107,8 @@ Item {
                   }
                   KeyHint { region: "footer"; action: "repeat"; sequences: ["Ctrl+R"] }
                 }
-                Button {
-                  iconText: "󰎈"
+                TransportButton {
+                  glyphText: "󰎈"
                   foreground: root.foreground
                   hasCursor: root.cursorOn("footer", "lyrics")
                   tooltipText: root.shortcutHint("Open lyrics in Omasing",

--- a/TransportButton.qml
+++ b/TransportButton.qml
@@ -1,0 +1,49 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+// Transport glyphs have very different font advances and ink bounds
+// (especially play/pause, shuffle and repeat). Give each one the same hit
+// target and center its painted bounds so a Row produces an even rhythm.
+Button {
+  id: root
+
+  property string glyphText: ""
+  property real glyphSize: Style.font.icon
+  property real controlSize: Style.space(32)
+
+  width: controlSize
+  height: controlSize
+  horizontalPadding: 0
+  verticalPadding: 0
+
+  readonly property int renderedGlyphSize: Math.max(1, Math.round(glyphSize))
+  readonly property real tightGlyphWidth: Math.max(1,
+    glyphMetrics.tightBoundingRect.width)
+  readonly property real tightGlyphHeight: Math.max(1,
+    glyphMetrics.tightBoundingRect.height)
+
+  TextMetrics {
+    id: glyphMetrics
+    font.family: root.fontFamily
+    font.pixelSize: root.renderedGlyphSize
+    text: root.glyphText
+  }
+
+  Text {
+    id: glyph
+    anchors.centerIn: parent
+    anchors.horizontalCenterOffset: implicitWidth / 2
+      - (glyphMetrics.tightBoundingRect.x + root.tightGlyphWidth / 2)
+    anchors.verticalCenterOffset: implicitHeight / 2
+      - (baselineOffset + glyphMetrics.tightBoundingRect.y
+        + root.tightGlyphHeight / 2)
+    text: root.glyphText
+    font.family: root.fontFamily
+    font.pixelSize: root.renderedGlyphSize
+    renderType: Text.NativeRendering
+    color: root.selected
+      ? Style.selectedStateColor(root.foreground, root.accent)
+      : root.foreground
+  }
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -27,7 +27,7 @@ omarchy plugin validate .
 qmllint -I /usr/share/omarchy/shell Api.js OAuth.js AuthManager.qml \
   SpotifyApi.qml SpotifyConnectManager.qml DaemonManager.qml BackendClient.qml Service.qml \
   BarWidget.qml PlaybackSlider.qml ArtistLinks.qml MediaByline.qml MediaRow.qml MediaCollection.qml \
-  ArtistSearchSection.qml LyricsInstallPrompt.qml ShortcutHint.qml Panel.qml
+  ArtistSearchSection.qml LyricsInstallPrompt.qml ShortcutHint.qml TransportButton.qml Panel.qml
 
 QT_QPA_PLATFORM=offscreen "$qml_test_runner" \
   -input tests \


### PR DESCRIPTION
## Why

The Spotify controls currently look out of rhythm with the rest of Omarchy. Each transport button sizes itself from the advance width of its font glyph, so the gaps vary from icon to icon and the larger play/pause glyph sits visibly below the surrounding controls.

The bar has a second version of the same problem: the Spotify app mark is placed in the smaller 21 px status slot while neighboring app icons use the standard 27 px icon slot. That leaves Spotify visibly crowded against the next widget.

## Before

Transport glyphs have uneven spacing and painted centers:

<img alt="Before: uneven spacing and alignment across Spotify transport controls" src="https://raw.githubusercontent.com/crmne/Omarchy-Spotify/pr-assets/pr-assets/transport-controls-before.png" width="608">

The Spotify bar mark is squeezed closer to its neighbors:

<img alt="Before: Spotify bar icon crowded between neighboring icons" src="https://raw.githubusercontent.com/crmne/Omarchy-Spotify/pr-assets/pr-assets/bar-icon-spacing-before.png" width="420">

## What this changes

- gives every transport action the same theme-scaled hit target
- centers the actual painted glyph bounds instead of the font advance box
- shares that transport control between the mini-player and full-player footer
- moves the Spotify mark onto the standard `BarIconButton`, app-icon slot, and optical canvas used by neighboring Omarchy icons

The result is one consistent visual grid across the bar, mini-player, and full player without per-icon spacing hacks.

## Testing

- `./scripts/test.sh`
- 15 Rust tests, 120 QML tests, 14 Python tests, Clippy, QML lint, plugin validation, and script tests pass