### PR TITLE
Keep paused Spotify sessions advertised and resumable

### DIFF
--- a/Api.js
+++ b/Api.js
@@ -116,8 +116,7 @@ function parseJson(text, fallback) {
   }
 }
 
-function barTrackText(title, artist, showTitle, showArtist, playing) {
-  if (playing !== true) return ""
+function barTrackText(title, artist, showTitle, showArtist) {
   var cleanTitle = String(title || "").trim()
   var cleanArtist = String(artist || "").trim()
   var parts = []
@@ -361,6 +360,14 @@ function visibleLocalReceiverAction(uiVisible, fullyConnected, running, busy) {
   if (busy === true) return "wait"
   if (running === true) return "refresh"
   return "start"
+}
+
+// A paused item is still an active media session: keep its MPRIS metadata and
+// resume controls alive after the UI closes. Only an empty/stopped receiver is
+// eligible for the configured background shutdown timeout.
+function idleShutdownShouldRun(daemonRunning, hasMedia, uiVisible, idleMinutes) {
+  return daemonRunning === true && hasMedia !== true && uiVisible !== true
+    && Number(idleMinutes) > 0
 }
 
 function remotePlaybackPollShouldRun(loggedIn, loading, uiVisible, useRemote,

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -20,7 +20,7 @@ BarWidget {
   readonly property string lyricsRequestKey: surfaceKey + "-lyrics"
   readonly property string barText: spotify
     ? Api.barTrackText(spotify.title, spotify.artist,
-      spotify.showTrackTitle, spotify.showArtistName, spotify.playing) : ""
+      spotify.showTrackTitle, spotify.showArtistName) : ""
   readonly property bool miniPlayerEnabled:
     String(root.setting("showMiniPlayer", "On")) !== "Off"
   readonly property bool iconOnly: !spotify || vertical || !spotify.hasMedia

--- a/Panel.qml
+++ b/Panel.qml
@@ -6523,7 +6523,7 @@ Item {
 
             Text {
               width: parent.width
-              text: "This computer stays visible in Spotify Connect while the player is open. After it closes, playback support sleeps at the idle timeout. Use 0 minutes to keep this computer available even while the player is closed. Device name and audio quality changes apply the next time local playback starts."
+              text: "This computer stays visible in Spotify Connect while the player is open. After it closes, an empty receiver sleeps at the idle timeout; paused media stays available to resume. Use 0 minutes to keep this computer available even while the player is closed. Device name and audio quality changes apply the next time local playback starts."
               color: root.muted
               font.family: root.fontFamily
               font.pixelSize: Style.font.bodySmall

--- a/Service.qml
+++ b/Service.qml
@@ -3888,8 +3888,8 @@ Item {
     id: idleTimer
     interval: 60000
     repeat: true
-    running: root.daemon.running && !root.playing && !root.uiVisible
-      && root.idleShutdownMinutes > 0
+    running: Api.idleShutdownShouldRun(root.daemon.running, root.hasMedia,
+      root.uiVisible, root.idleShutdownMinutes)
     onTriggered: {
       if (Date.now() - root.lastActivityAt >= root.idleShutdownMinutes * 60000)
         root.stopEngine()

--- a/manifest.json
+++ b/manifest.json
@@ -52,12 +52,12 @@
       {
         "key": "idleShutdownMinutes",
         "type": "integer",
-        "label": "Stop local playback when idle",
+        "label": "Sleep empty local receiver",
         "min": 0,
         "max": 1440,
         "step": 5,
         "defaultValue": 15,
-        "description": "Minutes after the player closes. Use 0 to keep this computer available even while the player is closed."
+        "description": "Minutes after the player closes when no media is loaded. Paused media stays available to resume. Use 0 to keep this computer available even while the player is closed."
       },
       {
         "key": "showMiniPlayer",

--- a/tests/tst_api.qml
+++ b/tests/tst_api.qml
@@ -12,22 +12,30 @@ TestCase {
   }
 
   function test_barTrackText_respectsIndependentTitleAndArtistSettings() {
-    compare(Api.barTrackText("Blue in Green", "Miles Davis", true, false, true),
+    compare(Api.barTrackText("Blue in Green", "Miles Davis", true, false),
       "Blue in Green")
-    compare(Api.barTrackText("Blue in Green", "Miles Davis", false, true, true),
+    compare(Api.barTrackText("Blue in Green", "Miles Davis", false, true),
       "Miles Davis")
-    compare(Api.barTrackText("Blue in Green", "Miles Davis", true, true, true),
+    compare(Api.barTrackText("Blue in Green", "Miles Davis", true, true),
       "Miles Davis - Blue in Green")
-    compare(Api.barTrackText("Blue in Green", "Miles Davis", false, false, true), "")
-    compare(Api.barTrackText("  Blue in Green  ", "  Miles Davis  ", true, true,
-      true),
+    compare(Api.barTrackText("Blue in Green", "Miles Davis", false, false), "")
+    compare(Api.barTrackText("  Blue in Green  ", "  Miles Davis  ", true, true),
       "Miles Davis - Blue in Green")
-    compare(Api.barTrackText("Blue in Green", "", true, true, true), "Blue in Green")
-    compare(Api.barTrackText("", "Miles Davis", true, true, true), "Miles Davis")
+    compare(Api.barTrackText("Blue in Green", "", true, true), "Blue in Green")
+    compare(Api.barTrackText("", "Miles Davis", true, true), "Miles Davis")
   }
 
-  function test_barTrackText_isHiddenWhilePaused() {
-    compare(Api.barTrackText("Blue in Green", "Miles Davis", true, true, false), "")
+  function test_barTrackText_keepsPausedMediaVisible() {
+    compare(Api.barTrackText("Blue in Green", "Miles Davis", true, true),
+      "Miles Davis - Blue in Green")
+  }
+
+  function test_idleShutdown_onlyRunsForAnEmptyReceiver() {
+    verify(Api.idleShutdownShouldRun(true, false, false, 15))
+    verify(!Api.idleShutdownShouldRun(true, true, false, 15))
+    verify(!Api.idleShutdownShouldRun(true, false, true, 15))
+    verify(!Api.idleShutdownShouldRun(false, false, false, 15))
+    verify(!Api.idleShutdownShouldRun(true, false, false, 0))
   }
 
   function test_scrollAvailability_requiresAtLeastOneBarLabel() {


### PR DESCRIPTION
## Why

The other media players Omarchy integrates through MPRIS treat **Paused** as an active media session: the current track remains advertised and the Play action can resume it. Omarchy Spotify currently behaves more like **Stopped**. It immediately removes the title and artist from the bar, then the idle timeout can tear down the receiver and its MPRIS metadata completely.

That makes a simple pause look as if Spotify forgot what was playing, and it prevents Omarchy media surfaces from representing the session the same way they represent other players.

## What this changes

- keeps the configured title and artist visible in the bar while playback is paused
- keeps paused MPRIS metadata and resume controls alive after the player surfaces close
- applies the idle shutdown timeout only when the receiver has no loaded media
- updates the setting copy so the distinction between paused and empty is clear
- covers paused metadata and empty-receiver shutdown behavior in QML tests

After this change, **paused means paused**: Spotify stays advertised and resumable like the other players. A genuinely stopped, empty receiver can still shut down after the configured timeout.

## Testing

- `./scripts/test.sh`
- 15 Rust tests, 121 QML tests, 14 Python tests, Clippy, QML lint, plugin validation, and script tests pass