### PR TITLE
Apply volume live while dragging the slider

### DIFF
--- a/Api.js
+++ b/Api.js
@@ -502,8 +502,21 @@ function spotifyTypeLabel(type) {
 var MUTE_THRESHOLD = 0.001
 var UNMUTE_FLOOR = 0.05
 var SEARCH_DEBOUNCE_MS = 600
+// Dragging a volume slider sends a command per frame, so each backend gets its
+// own flush cadence. Local spotifyd only writes an MPRIS property, the Web API
+// is rate limited, and the Sonos helper spawns a process per command and drops
+// anything that arrives while it is busy.
 var VOLUME_FLUSH_MS = 80
+var VOLUME_FLUSH_REMOTE_MS = 250
+var VOLUME_FLUSH_SONOS_MS = 120
 var SLIDER_VOLUME_ACK_TOLERANCE = 0.04
+
+function volumeFlushInterval(target) {
+  var backend = String(target || "").trim().toLowerCase()
+  if (backend === "remote") return VOLUME_FLUSH_REMOTE_MS
+  if (backend === "sonos") return VOLUME_FLUSH_SONOS_MS
+  return VOLUME_FLUSH_MS
+}
 
 function nextVolume(current, delta) {
   return clampUnit((Number(current) || 0) + (Number(delta) || 0))

--- a/Api.js
+++ b/Api.js
@@ -502,10 +502,6 @@ function spotifyTypeLabel(type) {
 var MUTE_THRESHOLD = 0.001
 var UNMUTE_FLOOR = 0.05
 var SEARCH_DEBOUNCE_MS = 600
-// Dragging a volume slider sends a command per frame, so each backend gets its
-// own flush cadence. Local spotifyd only writes an MPRIS property, the Web API
-// is rate limited, and the Sonos helper spawns a process per command and drops
-// anything that arrives while it is busy.
 var VOLUME_FLUSH_MS = 80
 var VOLUME_FLUSH_REMOTE_MS = 250
 var VOLUME_FLUSH_SONOS_MS = 120

--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -362,12 +362,17 @@ BarWidget {
       spotify.lengthSeconds))
   }
 
+  function setVolumeValue(value, live) {
+    if (!spotify || !spotify.volumeSupported) return false
+    var next = Api.nextVolume(value, 0)
+    if (Api.shouldRememberVolume(next)) volumeBeforeMute = next
+    spotify.setVolume(next, live === true)
+    return true
+  }
+
   function adjustVolume(delta) {
     if (!spotify || !spotify.volumeSupported) return false
-    var next = Api.nextVolume(spotify.volume, delta)
-    if (Api.shouldRememberVolume(next)) volumeBeforeMute = next
-    spotify.setVolume(next)
-    return true
+    return setVolumeValue(Api.nextVolume(spotify.volume, delta), false)
   }
 
   function toggleMute() {
@@ -1195,8 +1200,9 @@ BarWidget {
             sourcePending: root.spotify && root.spotify.volumePending
             contextKey: root.spotify ? root.spotify.playbackDeviceName : ""
             enabled: root.spotify && root.spotify.volumeSupported
-            onCommitted: function(value) {
-              if (root.spotify) root.spotify.setVolume(value)
+            liveCommit: true
+            onCommitted: function(value, live) {
+              root.setVolumeValue(value, live)
             }
           }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Apply volume while the volume slider is dragged, in both the bar popup and the
+  player, instead of waiting for the mouse release. Commands are coalesced per
+  backend: 80 ms for local spotifyd, 250 ms for Spotify Connect devices so the
+  Web API is not rate limited, and 120 ms retries for a Sonos whose helper is
+  still busy, so the released position is always the volume that lands. Playback
+  state is refetched once the drag settles rather than after every command.
+- Remember the pre-mute level when the bar popup volume slider is used, so `M`
+  restores the dragged volume.
+
 ## 1.0.3 — 2026-08-26
 
 - Download playback backends only from an exact-tag GitHub release whose raw

--- a/Panel.qml
+++ b/Panel.qml
@@ -1714,11 +1714,11 @@ Item {
       service.lengthSeconds))
   }
 
-  function setPanelVolume(value) {
+  function setPanelVolume(value, live) {
     if (!service || !service.volumeSupported) return
     var next = Api.nextVolume(value, 0)
     if (Api.shouldRememberVolume(next)) volumeBeforeMute = next
-    service.setVolume(next)
+    service.setVolume(next, live === true)
   }
 
   function adjustVolume(delta) {
@@ -4245,7 +4245,10 @@ Item {
                   sourceValue: root.service ? root.service.volume : 0
                   sourcePending: root.service && root.service.volumePending
                   contextKey: root.service ? root.service.playbackDeviceName : ""
-                  onCommitted: function(value) { root.setPanelVolume(value) }
+                  liveCommit: true
+                  onCommitted: function(value, live) {
+                    root.setPanelVolume(value, live)
+                  }
                   onRightClicked: root.toggleMute()
 
                   HoverHandler { id: volumeSliderHover }

--- a/PlaybackSlider.qml
+++ b/PlaybackSlider.qml
@@ -15,6 +15,9 @@ PanelSlider {
   property int minimumFeedbackMs: 300
   property int feedbackTimeoutMs: 8000
   property string contextKey: ""
+  // Volume applies while the knob moves; seek waits for release so a drag does
+  // not make the player re-buffer on every frame.
+  property bool liveCommit: false
 
   property real pendingValue: -1
   property double pendingStartedAt: 0
@@ -23,7 +26,7 @@ PanelSlider {
 
   value: awaitingFeedback ? pendingValue : sourceValue
 
-  signal committed(real value)
+  signal committed(real value, bool live)
 
   function preview(value) {
     pendingValue = Math.max(minimum, Math.min(maximum, Number(value) || 0))
@@ -37,13 +40,18 @@ PanelSlider {
     pendingContextKey = ""
   }
 
-  onMoved: function(value) { preview(value) }
+  onMoved: function(value) {
+    preview(value)
+    // A wheel notch emits moved() and released() with dragging still false, so
+    // gating here keeps it at a single commit through the released() path.
+    if (liveCommit && dragging) committed(pendingValue, true)
+  }
   onReleased: function(value) {
     preview(value)
     pendingStartedAt = Date.now()
     pendingContextKey = contextKey
     feedbackTimer.restart()
-    committed(pendingValue)
+    committed(pendingValue, false)
   }
   onContextKeyChanged: {
     if (awaitingFeedback && pendingContextKey

--- a/PlaybackSlider.qml
+++ b/PlaybackSlider.qml
@@ -15,8 +15,6 @@ PanelSlider {
   property int minimumFeedbackMs: 300
   property int feedbackTimeoutMs: 8000
   property string contextKey: ""
-  // Volume applies while the knob moves; seek waits for release so a drag does
-  // not make the player re-buffer on every frame.
   property bool liveCommit: false
 
   property real pendingValue: -1

--- a/Service.qml
+++ b/Service.qml
@@ -104,8 +104,6 @@ Item {
   property bool volumeFlushQueued: false
   property real queuedVolumeSlider: 0
   property bool volumeFlushCooling: false
-  // True while a slider drag keeps feeding values. Playback state is refetched
-  // once the drag settles instead of after every command.
   property bool volumeLiveActive: false
   property int remoteControlSerial: 0
   readonly property int remoteControlGraceMs: 8000
@@ -1059,8 +1057,6 @@ Item {
         root.clearPendingRemoteVolume(remoteSerial)
         root.clearPendingSliderVolume()
       }
-      // A live drag refetches once through volumeLiveIdleTimer rather than
-      // after every command.
       if (!ok || !root.volumeLiveActive) root.loadPlaybackState()
     })
     return true

--- a/Service.qml
+++ b/Service.qml
@@ -104,6 +104,9 @@ Item {
   property bool volumeFlushQueued: false
   property real queuedVolumeSlider: 0
   property bool volumeFlushCooling: false
+  // True while a slider drag keeps feeding values. Playback state is refetched
+  // once the drag settles instead of after every command.
+  property bool volumeLiveActive: false
   property int remoteControlSerial: 0
   readonly property int remoteControlGraceMs: 8000
   property string remoteVolumeProbeKey: ""
@@ -203,7 +206,9 @@ Item {
     clearPendingSliderVolume()
     volumeFlushQueued = false
     volumeFlushCooling = false
+    volumeLiveActive = false
     if (volumeFlushTimer) volumeFlushTimer.stop()
+    if (volumeLiveIdleTimer) volumeLiveIdleTimer.stop()
   }
   readonly property bool shuffle: useRemotePlayback
     ? remotePlayback.shuffle === true
@@ -1022,11 +1027,21 @@ Item {
       clearPendingSliderVolume()
   }
 
+  function volumeFlushTarget() {
+    if (sonosControlAvailable && sonosControlDevice && sonosControlDevice.id)
+      return "sonos"
+    return useRemotePlayback ? "remote" : "local"
+  }
+
+  // Returns false when the backend could not take the command, so the caller
+  // keeps it queued and retries. Only Sonos rejects this way.
   function sendVolumeCommand(sliderValue) {
     var localVolume = !useRemotePlayback && hasLocalPlayer
       && activePlayer.volumeSupported
     var normalized = localVolume
       ? Api.sliderToSpotifydVolume(sliderValue) : sliderValue
+    var sonos = volumeFlushTarget() === "sonos"
+    if (sonos && spotifyConnectManager.controlBusy) return false
     var remoteSerial = 0
     if (!localVolume && useRemotePlayback && remoteDevice) {
       var remotePercent = Math.round(normalized * 100)
@@ -1034,7 +1049,7 @@ Item {
       var receiver = findDiscoveredReceiver(remoteDevice)
       if (receiver) spotifyConnectManager.rememberVolume(receiver.id, remotePercent)
     }
-    if (sendSonosControl("volume", String(Math.round(normalized * 100)))) return
+    if (sendSonosControl("volume", String(Math.round(normalized * 100)))) return true
     if (localVolume)
       activePlayer.volume = normalized
     else apiAction("PUT", "/me/player/volume",
@@ -1044,8 +1059,11 @@ Item {
         root.clearPendingRemoteVolume(remoteSerial)
         root.clearPendingSliderVolume()
       }
-      root.loadPlaybackState()
+      // A live drag refetches once through volumeLiveIdleTimer rather than
+      // after every command.
+      if (!ok || !root.volumeLiveActive) root.loadPlaybackState()
     })
+    return true
   }
 
   function flushVolume() {
@@ -1054,9 +1072,8 @@ Item {
       return
     }
     var sliderValue = queuedVolumeSlider
-    volumeFlushQueued = false
     beginPendingSliderVolume(sliderValue)
-    sendVolumeCommand(sliderValue)
+    if (sendVolumeCommand(sliderValue)) volumeFlushQueued = false
     volumeFlushCooling = true
     if (volumeFlushTimer) volumeFlushTimer.restart()
   }
@@ -3191,9 +3208,13 @@ Item {
     })
   }
 
-  function setVolume(value) {
+  function setVolume(value, live) {
     var sliderValue = Math.max(0, Math.min(1, Number(value) || 0))
     noteActivity()
+    if (live === true) {
+      volumeLiveActive = true
+      volumeLiveIdleTimer.restart()
+    }
     beginPendingSliderVolume(sliderValue)
     queuedVolumeSlider = sliderValue
     volumeFlushQueued = true
@@ -3461,7 +3482,9 @@ Item {
     clearPendingSliderVolume()
     volumeFlushQueued = false
     volumeFlushCooling = false
+    volumeLiveActive = false
     volumeFlushTimer.stop()
+    volumeLiveIdleTimer.stop()
     remoteControlSerial = 0
     remoteVolumeProbeKey = ""
     remoteControlDiscoveryKey = ""
@@ -3872,9 +3895,21 @@ Item {
 
   Timer {
     id: volumeFlushTimer
-    interval: Api.VOLUME_FLUSH_MS
+    interval: Api.volumeFlushInterval(root.volumeFlushTarget())
     repeat: false
     onTriggered: root.flushVolume()
+  }
+
+  Timer {
+    id: volumeLiveIdleTimer
+    interval: 400
+    repeat: false
+    onTriggered: {
+      root.volumeLiveActive = false
+      // Only the remote path skipped its per-command refetch; a local MPRIS
+      // write reports the new volume on its own.
+      if (root.useRemotePlayback) root.loadPlaybackState()
+    }
   }
 
   Timer {

--- a/SpotifyConnectManager.qml
+++ b/SpotifyConnectManager.qml
@@ -29,6 +29,12 @@ Item {
   property string controlResult: ""
   property string lastError: ""
 
+  // control() silently drops commands while a helper process is in flight.
+  // Callers that repeat a command, such as a volume drag, check this so they can
+  // retry instead of losing the value they sent last.
+  readonly property bool controlBusy: controlling || controlCommand.running
+    || activating
+
   signal refreshed()
   signal refreshFailed(string reason)
   signal activated(string deviceId)

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -150,11 +150,10 @@ from RenderingControl because Spotify's `volume_percent` field is nullable; the
 UI remembers that value and updates it immediately after a volume command. The
 helper drops any command issued while an earlier one is still running, so a
 volume drag checks `controlBusy` and retries the queued value instead of losing
-it. When
-playback has moved elsewhere, a local Play wake is attempted first; the OAuth
-activation flow remains the fallback for a Sonos that has actually lost its
-Spotify session. Receiver discovery and requests are retried briefly because
-Sonos can sleep its endpoint during a handoff.
+it. When playback has moved elsewhere, a local Play wake is attempted first;
+the OAuth activation flow remains the fallback for a Sonos that has actually
+lost its Spotify session. Receiver discovery and requests are retried briefly
+because Sonos can sleep its endpoint during a handoff.
 
 The current-playback response is also merged into the device list. This matters
 for models that Spotify omits from `/me/player/devices`, or whose active device

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -47,6 +47,17 @@ transitions, seeks, and passthrough are unchanged. This fixes both the queued
 tail and the smaller waveform discontinuity without changing PipeWire routing
 or speaker tuning.
 
+Volume sliders apply while the knob moves; the seek slider still commits on
+release so a drag cannot make the player re-buffer per frame. A drag emits a
+command per input event, so `Service` coalesces them: the first value is sent
+immediately and later ones are queued and flushed at a per-backend interval,
+`Api.volumeFlushInterval` — 80 ms for a local MPRIS property write, 250 ms for
+the rate-limited Web API, and 120 ms for Sonos. The queued value is only cleared
+once a backend accepts the command, so the position the knob was released at is
+always the one that lands. The optimistic slider value is held until the player
+reports it, and playback state is refetched once the drag settles rather than
+after every command.
+
 ## Runtime requirements
 
 - Omarchy 4 with the Quickshell shell enabled
@@ -136,7 +147,10 @@ AVTransport or RenderingControl actions for play, pause, previous, next, seek,
 shuffle/repeat mode, and volume. Targets still come only from validated local
 Spotify Connect discovery. Discovery also reads the current Sonos master volume
 from RenderingControl because Spotify's `volume_percent` field is nullable; the
-UI remembers that value and updates it immediately after a volume command. When
+UI remembers that value and updates it immediately after a volume command. The
+helper drops any command issued while an earlier one is still running, so a
+volume drag checks `controlBusy` and retries the queued value instead of losing
+it. When
 playback has moved elsewhere, a local Play wake is attempted first; the OAuth
 activation flow remains the fallback for a Sonos that has actually lost its
 Spotify session. Receiver discovery and requests are retried briefly because

--- a/tests/tst_api.qml
+++ b/tests/tst_api.qml
@@ -163,6 +163,18 @@ TestCase {
     compare(Api.seekPosition(40, 10, 0), 50)
   }
 
+  function test_volumeFlushInterval_slowsDownForNetworkBackends() {
+    compare(Api.volumeFlushInterval("local"), Api.VOLUME_FLUSH_MS)
+    compare(Api.volumeFlushInterval("remote"), Api.VOLUME_FLUSH_REMOTE_MS)
+    compare(Api.volumeFlushInterval("sonos"), Api.VOLUME_FLUSH_SONOS_MS)
+    compare(Api.volumeFlushInterval("SONOS"), Api.VOLUME_FLUSH_SONOS_MS)
+    compare(Api.volumeFlushInterval(""), Api.VOLUME_FLUSH_MS)
+    compare(Api.volumeFlushInterval(null), Api.VOLUME_FLUSH_MS)
+    compare(Api.volumeFlushInterval("unknown"), Api.VOLUME_FLUSH_MS)
+    verify(Api.VOLUME_FLUSH_REMOTE_MS > Api.VOLUME_FLUSH_SONOS_MS)
+    verify(Api.VOLUME_FLUSH_SONOS_MS > Api.VOLUME_FLUSH_MS)
+  }
+
   function test_pendingSliderVolumeHoldsUntilPlayerAcknowledgesIt() {
     var pending = { slider: 0.55, expiresAt: 9000 }
     verify(Api.pendingSliderVolumeShouldHold(0.5, pending, 2000))


### PR DESCRIPTION
## Summary
- Volume sliders only sent a command on mouse release; now `PlaybackSlider` commits on every move during a drag, so users hear the level change live. Seek stays release-only to avoid re-buffering.
- Per-backend flush cadence keeps this cheap: 80ms for local spotifyd, 250ms for the rate-limited Spotify Web API, 120ms retries for Sonos (whose helper drops commands issued while busy). The queued value only clears once a backend accepts it, so the released position always lands. Playback state refetches once after a drag settles instead of after every command.
- Trimmed comments added alongside this change that only restated what the code already said; kept the ones documenting non-obvious behavior (a Qt wheel-notch quirk, the silent-drop semantics of the Sonos control helper, and the return-value contract of `sendVolumeCommand`).

## Test plan
- [x] `tests/tst_api.qml` covers `Api.volumeFlushInterval` per backend
- [x] Manually tested against a Sonos receiver and an Echo Dot — live audio feedback while dragging, no stuck/lost final value
- [x] Confirmed seek slider still only commits on release