### PR TITLE
Make Omarchy Spotify fully uninstallable

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,53 @@ packaged `spotifyd` fallback instead of executing an unverified download.
 
 > Requires Omarchy 4 and a personal Spotify Premium account.
 
+## Remove it completely
+
+Run the bundled uninstaller from outside the plugin directory:
+
+```bash
+cd "$HOME" && "$HOME/.config/omarchy/plugins/quickshell.spotify/scripts/uninstall.sh"
+```
+
+It disables and removes the plugin, stops and removes both user services,
+restarts the shell, and deletes all plugin-owned configuration, cached audio,
+backend build files, installed binaries, playback state, runtime sockets, old
+configuration backups, and matching GNOME Keyring entries.
+
+If you prefer to inspect and paste the main steps individually:
+
+```bash
+plugin_dir="$HOME/.config/omarchy/plugins/quickshell.spotify"
+cd "$HOME"
+omarchy plugin disable quickshell.spotify 2>/dev/null || true
+"$plugin_dir/scripts/remove-runtime.sh" --purge
+omarchy plugin remove quickshell.spotify --yes
+omarchy restart shell
+```
+
+The cleanup deliberately leaves unrelated software alone. A source checkout
+outside Omarchy's plugin directory, separate plugins such as Omasing, and the
+`spotifyd` package remain in place. If this plugin was the only reason you
+installed the fallback package, remove it with:
+
+```bash
+omarchy pkg drop spotifyd
+```
+
+Very old installation instructions may also have added a custom Hyprland
+shortcut. The uninstaller reports any such references without rewriting your
+personal configuration. Check both the live config and, when applicable, its
+chezmoi source:
+
+```bash
+rg -n 'quickshell\.spotify|Omarchy Spotify' \
+  "$HOME/.config/hypr" "$HOME/.local/share/chezmoi" 2>/dev/null
+```
+
+Remove only the matching custom lines, apply the dotfiles change, and run
+`hyprctl reload`. Omarchy's stock **Super+Shift+M** Music shortcut will then be
+used again.
+
 ## More music, less app
 
 - Discover Weekly, Release Radar, Daily Mixes, daylist, and more in **Discover**.

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -198,24 +198,22 @@ See [Benchmark](BENCHMARK.md) for methodology and recorded results.
 
 ## Complete removal
 
-Log out in the app first, then remove the plugin. Before deleting the checkout,
-run:
+Run the bundled uninstaller from outside the plugin directory:
 
 ```bash
-./scripts/remove-runtime.sh --purge
-omarchy plugin remove quickshell.spotify --yes
+cd "$HOME" && "$HOME/.config/omarchy/plugins/quickshell.spotify/scripts/uninstall.sh"
 ```
 
-This stops and removes both static user units and the installed backend binary,
-deletes the app's private playback config, durable playback authorization,
-player session state, and cached audio,
-and clears matching Omarchy Spotify keyring entries. The `spotifyd` package
-remains installed because another client may use it.
+This removes the plugin and all plugin-owned services, binaries, config, state,
+caches, sockets, backups, and keyring entries. See the README's
+**Remove it completely** section for the equivalent commands and legacy
+keybinding check. The `spotifyd` package remains installed because another
+client may use it.
 
 Remove that package separately only when it was installed solely for this app:
 
 ```bash
-sudo pacman -Rns spotifyd
+omarchy pkg drop spotifyd
 ```
 
 ## Upstream projects

--- a/scripts/remove-runtime.sh
+++ b/scripts/remove-runtime.sh
@@ -14,22 +14,47 @@ fi
 config_root=${XDG_CONFIG_HOME:-"$HOME/.config"}
 cache_root=${XDG_CACHE_HOME:-"$HOME/.cache"}
 state_root=${XDG_STATE_HOME:-"$HOME/.local/state"}
+session_runtime_root=${XDG_RUNTIME_DIR:-/tmp}
 backend_unit_file="$config_root/systemd/user/omarchy-spotify.service"
 fallback_unit_file="$config_root/systemd/user/omarchy-spotifyd.service"
 config_dir="$config_root/omarchy-spotify"
 cache_dir="$cache_root/spotifyd"
+build_cache_dir="$cache_root/omarchy-spotify"
 state_dir="$state_root/omarchy-spotify"
+session_runtime_dir="$session_runtime_root/omarchy-spotify"
 runtime_dir=${OMARCHY_SPOTIFY_RUNTIME_DIR:-"$HOME/.local/lib/omarchy-spotify"}
 backend_binary="$runtime_dir/omarchy-spotify-backend"
 backend_source_id_file="$runtime_dir/backend-source.sha256"
 backend_binary_hash_file="$runtime_dir/backend-binary.sha256"
 backend_origin_file="$runtime_dir/backend-origin"
 
-systemctl --user stop omarchy-spotify.service 2>/dev/null || true
-systemctl --user stop omarchy-spotifyd.service 2>/dev/null || true
+require_safe_path() {
+  local label=$1 value=$2
+
+  [[ $value == /* && $value != / ]] || {
+    echo "remove-runtime.sh: refusing unsafe $label path: $value" >&2
+    exit 3
+  }
+}
+
+require_safe_path "configuration root" "$config_root"
+require_safe_path "cache root" "$cache_root"
+require_safe_path "state root" "$state_root"
+require_safe_path "session runtime root" "$session_runtime_root"
+require_safe_path "backend runtime" "$runtime_dir"
+runtime_dir_is_dedicated=0
+if [[ ${runtime_dir##*/} == omarchy-spotify ]]; then
+  runtime_dir_is_dedicated=1
+fi
+
+for unit_name in omarchy-spotify.service omarchy-spotifyd.service; do
+  systemctl --user disable --now "$unit_name" >/dev/null 2>&1 || true
+done
 rm -f -- "$backend_unit_file" "$fallback_unit_file" "$backend_binary" \
   "$backend_source_id_file" "$backend_binary_hash_file" "$backend_origin_file"
 systemctl --user daemon-reload
+systemctl --user reset-failed omarchy-spotify.service omarchy-spotifyd.service \
+  >/dev/null 2>&1 || true
 
 if [[ -d $config_dir ]]; then
   if (( purge )); then
@@ -44,26 +69,49 @@ if [[ -d $config_dir ]]; then
 fi
 
 if (( purge )); then
-  [[ $state_root == /* && $state_root != / ]] || {
-    echo "remove-runtime.sh: refusing an unsafe state path" >&2
-    exit 3
-  }
   if [[ -d $cache_dir ]]; then
     [[ $cache_dir == "$cache_root/spotifyd" ]] || exit 3
     rm -rf -- "$cache_dir"
     echo "Removed spotifyd cached credentials and audio."
+  fi
+  if [[ -d $build_cache_dir ]]; then
+    [[ $build_cache_dir == "$cache_root/omarchy-spotify" ]] || exit 3
+    rm -rf -- "$build_cache_dir"
+    echo "Removed backend build cache."
   fi
   if [[ -d $state_dir ]]; then
     [[ $state_dir == "$state_root/omarchy-spotify" ]] || exit 3
     rm -rf -- "$state_dir"
     echo "Removed durable playback authorization and session state."
   fi
+  if [[ -d $session_runtime_dir ]]; then
+    [[ $session_runtime_dir == "$session_runtime_root/omarchy-spotify" ]] || exit 3
+    rm -rf -- "$session_runtime_dir"
+    echo "Removed playback sockets and temporary receiver state."
+  fi
+  if [[ -d $runtime_dir ]]; then
+    if (( runtime_dir_is_dedicated )); then
+      rm -rf -- "$runtime_dir"
+      echo "Removed installed playback backend."
+    elif rmdir -- "$runtime_dir" 2>/dev/null; then
+      echo "Removed empty custom backend directory."
+    else
+      echo "Kept unknown files in custom backend directory: $runtime_dir" >&2
+    fi
+  fi
+  for backup in "$config_root"/omarchy-spotify.bak.*; do
+    [[ -e $backup ]] || continue
+    rm -rf -- "$backup"
+    echo "Removed old configuration backup: $backup"
+  done
   if command -v secret-tool >/dev/null 2>&1; then
-    for _ in {1..20}; do
+    for _ in {1..100}; do
       secret-tool clear service quickshell-spotify kind refresh-token >/dev/null 2>&1 || break
     done
     echo "Cleared matching Omarchy Spotify keyring entries."
   fi
+else
+  rmdir -- "$runtime_dir" 2>/dev/null || true
 fi
 
 echo "Runtime integration removed. The spotifyd package was left installed."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# > 0 )); then
+  echo "Usage: scripts/uninstall.sh" >&2
+  exit 2
+fi
+
+source_root=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+plugins_dir="$HOME/.config/omarchy/plugins"
+plugin_dir="$plugins_dir/quickshell.spotify"
+
+[[ $HOME == /* && $HOME != / ]] || {
+  echo "uninstall.sh: refusing an unsafe home path" >&2
+  exit 3
+}
+command -v omarchy >/dev/null 2>&1 || {
+  echo "uninstall.sh: Omarchy is not installed" >&2
+  exit 1
+}
+
+# Disable first so the shell drops its widget and service before the runtime
+# files and plugin checkout disappear. This is intentionally safe to repeat.
+omarchy plugin disable quickshell.spotify >/dev/null 2>&1 || true
+"$source_root/scripts/remove-runtime.sh" --purge
+
+if [[ -e $plugin_dir || -L $plugin_dir ]]; then
+  omarchy plugin remove quickshell.spotify --yes
+fi
+
+# Omarchy backs up unmanaged plugin folders instead of deleting them. A full
+# uninstall explicitly removes only backups bearing this plugin's exact ID.
+for backup in "$plugins_dir"/.quickshell.spotify.bak.*; do
+  [[ -e $backup ]] || continue
+  rm -rf -- "$backup"
+done
+
+omarchy restart shell
+
+hypr_config="$HOME/.config/hypr"
+if command -v rg >/dev/null 2>&1 && [[ -d $hypr_config ]] \
+    && rg -q 'quickshell\.spotify|Omarchy Spotify' "$hypr_config"; then
+  echo >&2
+  echo "Legacy Omarchy Spotify references remain in Hyprland config:" >&2
+  rg -n 'quickshell\.spotify|Omarchy Spotify' "$hypr_config" >&2 || true
+  echo "Remove those custom lines (and their dotfiles source), then run hyprctl reload." >&2
+fi
+
+echo "Omarchy Spotify's plugin data and runtime have been completely uninstalled."
+echo "External source checkouts, other plugins, and the spotifyd package were left alone."

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -63,11 +63,15 @@ mock_bin="$test_root/mock-bin"
 runtime_config="$test_root/runtime-config"
 runtime_cache="$test_root/runtime-cache"
 runtime_state="$test_root/runtime-state"
-runtime_backend="$test_root/runtime-backend"
+runtime_session="$test_root/runtime-session"
+runtime_backend="$test_root/runtime-lib/omarchy-spotify"
+runtime_home="$test_root/runtime-home"
 mock_target="$test_root/mock-target"
 secret_log="$test_root/secret-tool.log"
 systemctl_log="$test_root/systemctl.log"
-mkdir -p "$mock_bin" "$runtime_config" "$runtime_cache" "$runtime_state" "$runtime_backend"
+omarchy_log="$test_root/omarchy.log"
+mkdir -p "$mock_bin" "$runtime_config" "$runtime_cache" "$runtime_state" \
+  "$runtime_session" "$runtime_backend" "$runtime_home"
 
 printf '%s\n' '#!/bin/sh' 'exit 0' >"$mock_bin/spotifyd"
 printf '%s\n' \
@@ -87,7 +91,15 @@ printf '%s\n' \
   '#!/bin/sh' \
   'printf "%s\n" "$*" >>"${TEST_SECRET_LOG:?}"' \
   'exit 1' >"$mock_bin/secret-tool"
-chmod 755 "$mock_bin/cargo" "$mock_bin/spotifyd" "$mock_bin/systemctl" "$mock_bin/secret-tool"
+printf '%s\n' \
+  '#!/bin/sh' \
+  'printf "%s\n" "$*" >>"${TEST_OMARCHY_LOG:?}"' \
+  'if [ "$*" = "plugin remove quickshell.spotify --yes" ]; then' \
+  '  rm -f -- "$HOME/.config/omarchy/plugins/quickshell.spotify"' \
+  'fi' \
+  'exit 0' >"$mock_bin/omarchy"
+chmod 755 "$mock_bin/cargo" "$mock_bin/spotifyd" "$mock_bin/systemctl" \
+  "$mock_bin/secret-tool" "$mock_bin/omarchy"
 
 [[ -x $source_root/scripts/spotify-connect-device.py ]]
 "$source_root/scripts/spotify-connect-device.py" self-test |
@@ -202,23 +214,88 @@ TEST_SYSTEMCTL_LOG="$systemctl_log" \
   "$source_root/scripts/setup.sh" >/dev/null
 ! grep -q -- '--user restart omarchy-spotify.service' "$systemctl_log"
 
-mkdir -p "$runtime_config/omarchy-spotify" "$runtime_cache/spotifyd"
+mkdir -p "$runtime_config/omarchy-spotify" \
+  "$runtime_config/omarchy-spotify.bak.20260827000000" \
+  "$runtime_cache/spotifyd" "$runtime_cache/omarchy-spotify/target" \
+  "$runtime_session/omarchy-spotify"
 cp -- "$source_root/config/spotifyd.conf" "$runtime_config/omarchy-spotify/spotifyd.conf"
+printf '%s\n' stale >"$runtime_config/omarchy-spotify.bak.20260827000000/spotifyd.conf"
+printf '%s\n' stale >"$runtime_cache/omarchy-spotify/target/build-artifact"
+printf '%s\n' stale >"$runtime_session/omarchy-spotify/backend.sock"
+: >"$systemctl_log"
 PATH="$mock_bin:$PATH" \
 XDG_CONFIG_HOME="$runtime_config" \
 XDG_CACHE_HOME="$runtime_cache" \
 XDG_STATE_HOME="$runtime_state" \
+XDG_RUNTIME_DIR="$runtime_session" \
 OMARCHY_SPOTIFY_RUNTIME_DIR="$runtime_backend" \
 TEST_SECRET_LOG="$secret_log" \
+TEST_SYSTEMCTL_LOG="$systemctl_log" \
   "$source_root/scripts/remove-runtime.sh" --purge >/dev/null
 
 [[ ! -e $runtime_config/omarchy-spotify && ! -e $runtime_cache/spotifyd ]]
+[[ ! -e $runtime_config/omarchy-spotify.bak.20260827000000 ]]
+[[ ! -e $runtime_cache/omarchy-spotify ]]
 [[ ! -e $runtime_state/omarchy-spotify ]]
-[[ ! -e $runtime_backend/omarchy-spotify-backend ]]
-[[ ! -e $runtime_backend/backend-source.sha256 ]]
-[[ ! -e $runtime_backend/backend-binary.sha256 ]]
-[[ ! -e $runtime_backend/backend-origin ]]
+[[ ! -e $runtime_session/omarchy-spotify ]]
+[[ ! -e $runtime_backend ]]
+grep -qx -- '--user disable --now omarchy-spotify.service' "$systemctl_log"
+grep -qx -- '--user disable --now omarchy-spotifyd.service' "$systemctl_log"
 grep -q 'clear service quickshell-spotify kind refresh-token' "$secret_log"
+
+set +e
+PATH="$mock_bin:$PATH" \
+XDG_CACHE_HOME="relative-cache" \
+  "$source_root/scripts/remove-runtime.sh" --purge >/dev/null 2>&1
+unsafe_remove_status=$?
+set -e
+[[ $unsafe_remove_status -eq 3 ]]
+
+# The top-level uninstaller wraps the runtime purge, removes the plugin through
+# Omarchy, clears exact-ID backups, restarts the shell, and remains idempotent.
+plugin_dir="$runtime_home/.config/omarchy/plugins/quickshell.spotify"
+plugin_backup="$runtime_home/.config/omarchy/plugins/.quickshell.spotify.bak.20260827000000"
+mkdir -p "$(dirname -- "$plugin_dir")" "$plugin_backup" \
+  "$runtime_config/omarchy-spotify" "$runtime_cache/spotifyd" \
+  "$runtime_state/omarchy-spotify" "$runtime_session/omarchy-spotify" \
+  "$runtime_backend"
+ln -s -- "$source_root" "$plugin_dir"
+printf '%s\n' stale >"$runtime_backend/omarchy-spotify-backend"
+: >"$omarchy_log"
+(
+  cd "$test_root"
+  PATH="$mock_bin:$PATH" \
+  HOME="$runtime_home" \
+  XDG_CONFIG_HOME="$runtime_config" \
+  XDG_CACHE_HOME="$runtime_cache" \
+  XDG_STATE_HOME="$runtime_state" \
+  XDG_RUNTIME_DIR="$runtime_session" \
+  OMARCHY_SPOTIFY_RUNTIME_DIR="$runtime_backend" \
+  TEST_SECRET_LOG="$secret_log" \
+  TEST_SYSTEMCTL_LOG="$systemctl_log" \
+  TEST_OMARCHY_LOG="$omarchy_log" \
+    "$source_root/scripts/uninstall.sh" >/dev/null
+)
+[[ ! -e $plugin_dir && ! -L $plugin_dir && ! -e $plugin_backup ]]
+[[ ! -e $runtime_config/omarchy-spotify && ! -e $runtime_cache/spotifyd ]]
+[[ ! -e $runtime_state/omarchy-spotify && ! -e $runtime_session/omarchy-spotify ]]
+[[ ! -e $runtime_backend ]]
+grep -qx 'plugin disable quickshell.spotify' "$omarchy_log"
+grep -qx 'plugin remove quickshell.spotify --yes' "$omarchy_log"
+grep -qx 'restart shell' "$omarchy_log"
+
+PATH="$mock_bin:$PATH" \
+HOME="$runtime_home" \
+XDG_CONFIG_HOME="$runtime_config" \
+XDG_CACHE_HOME="$runtime_cache" \
+XDG_STATE_HOME="$runtime_state" \
+XDG_RUNTIME_DIR="$runtime_session" \
+OMARCHY_SPOTIFY_RUNTIME_DIR="$runtime_backend" \
+TEST_SECRET_LOG="$secret_log" \
+TEST_SYSTEMCTL_LOG="$systemctl_log" \
+TEST_OMARCHY_LOG="$omarchy_log" \
+  "$source_root/scripts/uninstall.sh" >/dev/null
+[[ $(grep -c '^plugin remove quickshell.spotify --yes$' "$omarchy_log") -eq 1 ]]
 
 mkdir -p "$runtime_state/omarchy-spotify/oauth" "$runtime_cache/spotifyd/oauth"
 printf '%s\n' '{"mock":"credential"}' \
@@ -281,6 +358,10 @@ PATH="$mock_bin:$PATH" \
 grep -qx 'umask 077' "$source_root/scripts/spotifyd-auth.sh"
 [[ -x $source_root/scripts/setup-playback.sh ]]
 [[ -x $source_root/scripts/backend-source-id.sh ]]
+[[ -x $source_root/scripts/uninstall.sh ]]
+grep -q 'remove-runtime.sh.*--purge' "$source_root/scripts/uninstall.sh"
+grep -q 'omarchy plugin remove quickshell.spotify --yes' "$source_root/scripts/uninstall.sh"
+grep -q '^## Remove it completely$' "$source_root/README.md"
 grep -q 'pkexec /usr/bin/pacman -S --needed --noconfirm spotifyd' \
   "$source_root/scripts/setup-playback.sh"
 ! grep -q 'sudo' "$source_root/scripts/setup-playback.sh"


### PR DESCRIPTION
## Why

Installing local playback creates a footprint beyond the plugin checkout: user service files, an installed backend, private config and session state, GNOME Keyring entries, runtime sockets, a Cargo build cache, and spotifyd's cached audio. The existing removal note is buried in the technical docs and does not clean several of those locations or remove the plugin itself.

Removing the player should be as clear and dependable as installing it—especially when media shortcuts and shell widgets make a half-removed installation remain visible.

## What changed

- Add a prominent **Remove it completely** section to the README with both a one-command uninstaller and the equivalent copy/paste steps.
- Add `scripts/uninstall.sh` to disable the widget, purge runtime data, remove the plugin through Omarchy, clear exact-ID backups, and restart the shell.
- Expand `remove-runtime.sh --purge` to disable both units and remove build cache, audio cache, state, sockets, installed runtime files, config backups, and matching keyring entries.
- Report legacy Hyprland shortcut references and document how to check chezmoi sources without rewriting personal dotfiles.
- Keep unrelated source checkouts, other plugins, and the optional `spotifyd` package intact; document the explicit Omarchy package-removal command.
- Test the full artifact inventory, command orchestration, path guards, and repeat-run behavior.

## Verification

- `./scripts/test.sh`
  - 15 Rust tests
  - 120 QML tests
  - 14 Python tests
  - script tests, QML lint, manifest validation, and dependency checks
- `git diff --check`

This branch contains one commit based directly on current `main`; it does not depend on another open PR.