### PR TITLE
Harden Spotify API request transport

### DIFF
--- a/Api.js
+++ b/Api.js
@@ -288,11 +288,19 @@ function apiRequestIsMutating(method) {
   return value !== "GET" && value !== "HEAD"
 }
 
-function enqueueApiJob(queue, job, preferFront) {
+function apiJobPriority(job) {
+  if (!job) return 0
+  if (apiRequestIsMutating(job.method)) return 2
+  return String(job.priority || "") === "interactive" ? 1 : 0
+}
+
+function enqueueApiJob(queue, job) {
   var next = arrayValues(queue)
   if (!job) return next
-  if (preferFront === true || apiRequestIsMutating(job.method)) next.unshift(job)
-  else next.push(job)
+  var priority = apiJobPriority(job)
+  var index = 0
+  while (index < next.length && apiJobPriority(next[index]) >= priority) index++
+  next.splice(index, 0, job)
   return next
 }
 
@@ -510,6 +518,7 @@ function spotifyTypeLabel(type) {
 var MUTE_THRESHOLD = 0.001
 var UNMUTE_FLOOR = 0.05
 var SEARCH_DEBOUNCE_MS = 600
+var SEARCH_REQUEST_TIMEOUT_MS = 8000
 var VOLUME_FLUSH_MS = 80
 var VOLUME_FLUSH_REMOTE_MS = 250
 var VOLUME_FLUSH_SONOS_MS = 120

--- a/SpotifyApi.qml
+++ b/SpotifyApi.qml
@@ -24,13 +24,92 @@ Item {
   property bool restrictInFlight: false
   property bool pumpingRequests: false
   property bool pumpAgain: false
+  property var timedJobs: []
+  property var xhrFactory: function() { return new XMLHttpRequest() }
+  property var now: function() { return Date.now() }
+
+  function removeTimedJob(job) {
+    var next = []
+    for (var i = 0; i < timedJobs.length; i++)
+      if (timedJobs[i] !== job) next.push(timedJobs[i])
+    timedJobs = next
+  }
+
+  function removeQueuedHandle(handle) {
+    var next = []
+    for (var i = 0; i < requestQueue.length; i++)
+      if (!requestQueue[i] || requestQueue[i].handle !== handle)
+        next.push(requestQueue[i])
+    requestQueue = next
+  }
+
+  function abortXhr(xhr) {
+    if (!xhr || typeof xhr.abort !== "function") return
+    try {
+      xhr.abort()
+    } catch (error) {
+      console.warn("Spotify API request abort failed: " + Api.redact(error))
+    }
+  }
+
+  function markJobFinished(job) {
+    if (!job || job.finished === true) return
+    job.finished = true
+    removeTimedJob(job)
+    if (job.handle && job.handle.job === job) job.handle.job = null
+    return true
+  }
+
+  function deliverJob(job, status, payload, error, xhr) {
+    var elapsed = job.queuedAt !== undefined
+      ? Math.max(0, now() - job.queuedAt) : 0
+    if (error || elapsed >= 2000)
+      console.warn("Spotify API " + String(job.method || "GET") + " "
+        + Api.redact(String(job.path || "")) + " finished in " + elapsed + " ms"
+        + (error ? ": " + Api.redact(error) : ""))
+    releaseRequestSlot(job.handle)
+    callbackIfCurrent(job, status, payload, error, xhr)
+  }
+
+  function finishJob(job, status, payload, error, xhr) {
+    if (markJobFinished(job) !== true) return
+    deliverJob(job, status, payload, error, xhr)
+  }
+
+  function expireTimedOutRequests(timestamp) {
+    var current = Number(timestamp)
+    if (!isFinite(current)) current = now()
+    var jobs = timedJobs.slice()
+    for (var i = 0; i < jobs.length; i++) {
+      var job = jobs[i]
+      if (!job || job.finished === true || !job.deadlineAt
+          || current < job.deadlineAt) continue
+      var handle = job.handle
+      var xhr = handle ? handle.xhr : null
+      if (markJobFinished(job) !== true) continue
+      if (handle) {
+        handle.xhr = null
+        handle.aborted = true
+        removeQueuedHandle(handle)
+      }
+      abortXhr(xhr)
+      deliverJob(job, 0, null,
+        "Spotify took too long to respond. Try again.", null)
+    }
+  }
 
   function abortRequest(handle) {
     if (!handle || handle.aborted) return
     handle.aborted = true
+    removeQueuedHandle(handle)
     var xhr = handle.xhr
     handle.xhr = null
-    if (xhr && xhr.abort) xhr.abort()
+    if (handle.job && handle.job.finished !== true) {
+      handle.job.finished = true
+      removeTimedJob(handle.job)
+    }
+    handle.job = null
+    abortXhr(xhr)
     releaseRequestSlot(handle)
   }
 
@@ -40,8 +119,8 @@ Item {
     return Api.responseError(status, payload, fallback)
   }
 
-  function enqueueJob(job, preferFront) {
-    requestQueue = Api.enqueueApiJob(requestQueue, job, preferFront)
+  function enqueueJob(job) {
+    requestQueue = Api.enqueueApiJob(requestQueue, job)
     pumpRequests()
     return job.handle
   }
@@ -61,7 +140,7 @@ Item {
     pumpingRequests = true
     pumpAgain = false
     while (requestsInFlight < Api.apiInFlightLimit(restrictInFlight)) {
-      var wait = Api.apiCooldownMs(Date.now(), rateLimitedUntil)
+      var wait = Api.apiCooldownMs(now(), rateLimitedUntil)
       if (wait > 0) {
         rateLimitTimer.interval = Math.max(50, wait)
         rateLimitTimer.restart()
@@ -82,9 +161,7 @@ Item {
     var handle = job.handle
     var url = Api.safeApiUrl(job.path)
     if (!url) {
-      if (typeof job.callback === "function")
-        callbackIfCurrent(job, 0, null, "Something went wrong while contacting Spotify", null)
-      releaseRequestSlot(handle)
+      finishJob(job, 0, null, "Something went wrong while contacting Spotify", null)
       return
     }
     url = Api.appendQuery(url, job.query)
@@ -95,53 +172,59 @@ Item {
         return
       }
       if (!token) {
-        callbackIfCurrent(job, 0, null, tokenError || "Not logged in", null)
-        releaseRequestSlot(handle)
+        finishJob(job, 0, null, tokenError || "Not logged in", null)
         return
       }
-      var xhr = new XMLHttpRequest()
-      handle.xhr = xhr
-      xhr.onreadystatechange = function() {
-        if (xhr.readyState !== XMLHttpRequest.DONE) return
+      var xhr = null
+      try {
+        xhr = xhrFactory()
+        handle.xhr = xhr
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState !== XMLHttpRequest.DONE || handle.xhr !== xhr) return
+          handle.xhr = null
+          if (handle.aborted || job.finished === true) return
+          var payload = Api.parseJson(xhr.responseText, null)
+          if (xhr.status === 401 && job.retried !== true) {
+            auth.invalidateAccessToken()
+            job.retried = true
+            requestQueue = Api.enqueueApiJob(requestQueue, job)
+            releaseRequestSlot(handle)
+            return
+          }
+          if (xhr.status === 429) {
+            restrictInFlight = true
+            rateLimitedUntil = Api.nextRateLimitedUntil(now(),
+              Api.responseRetryAfter(xhr), rateLimitedUntil, job.rateLimitRetries)
+            if (job.retryRateLimit !== false
+                && Api.shouldRetryRateLimit(job.rateLimitRetries)) {
+              job.rateLimitRetries += 1
+              requestQueue = Api.enqueueApiJob(requestQueue, job)
+              releaseRequestSlot(handle)
+              return
+            }
+          } else {
+            restrictInFlight = false
+          }
+          var ok = xhr.status >= 200 && xhr.status < 300
+          var error = ok ? "" : root.requestError(xhr.status, payload, xhr,
+            "Spotify could not complete this request")
+          finishJob(job, xhr.status, payload, error, xhr)
+        }
+        xhr.open(String(job.method || "GET"), url)
+        xhr.setRequestHeader("Authorization", "Bearer " + token)
+        if (job.body !== undefined && job.body !== null) {
+          xhr.setRequestHeader("Content-Type", "application/json")
+          xhr.send(JSON.stringify(job.body))
+        } else {
+          xhr.send()
+        }
+      } catch (error) {
         if (handle.xhr === xhr) handle.xhr = null
         if (handle.aborted) {
           releaseRequestSlot(handle)
           return
         }
-        var payload = Api.parseJson(xhr.responseText, null)
-        if (xhr.status === 401 && job.retried !== true) {
-          auth.invalidateAccessToken()
-          job.retried = true
-          requestQueue = Api.enqueueApiJob(requestQueue, job, true)
-          releaseRequestSlot(handle)
-          return
-        }
-        if (xhr.status === 429) {
-          restrictInFlight = true
-          rateLimitedUntil = Api.nextRateLimitedUntil(Date.now(),
-            Api.responseRetryAfter(xhr), rateLimitedUntil, job.rateLimitRetries)
-          if (Api.shouldRetryRateLimit(job.rateLimitRetries)) {
-            job.rateLimitRetries += 1
-            requestQueue = Api.enqueueApiJob(requestQueue, job, true)
-            releaseRequestSlot(handle)
-            return
-          }
-        } else {
-          restrictInFlight = false
-        }
-        var ok = xhr.status >= 200 && xhr.status < 300
-        var error = ok ? "" : root.requestError(xhr.status, payload, xhr,
-          "Spotify could not complete this request")
-        callbackIfCurrent(job, xhr.status, payload, error, xhr)
-        releaseRequestSlot(handle)
-      }
-      xhr.open(String(job.method || "GET"), url)
-      xhr.setRequestHeader("Authorization", "Bearer " + token)
-      if (job.body !== undefined && job.body !== null) {
-        xhr.setRequestHeader("Content-Type", "application/json")
-        xhr.send(JSON.stringify(job.body))
-      } else {
-        xhr.send()
+        finishJob(job, 0, null, "Something went wrong while contacting Spotify", null)
       }
     })
   }
@@ -151,18 +234,30 @@ Item {
       job.callback(status, payload, error, xhr)
   }
 
-  function request(method, path, query, body, callback, retried, existingHandle) {
-    var handle = existingHandle || { aborted: false, xhr: null }
-    return enqueueJob({
+  function request(method, path, query, body, callback, options) {
+    var settings = options || ({})
+    var handle = { aborted: false, xhr: null, job: null }
+    var timeoutMs = Math.max(0, Number(settings.timeoutMs) || 0)
+    var queuedAt = now()
+    var job = {
       method: method,
       path: path,
       query: query,
       body: body,
       callback: callback,
-      retried: retried === true,
+      retried: false,
       rateLimitRetries: 0,
+      retryRateLimit: settings.retryRateLimit !== false,
+      priority: String(settings.priority || ""),
+      timeoutMs: timeoutMs,
+      queuedAt: queuedAt,
+      deadlineAt: timeoutMs > 0 ? queuedAt + timeoutMs : 0,
+      finished: false,
       handle: handle
-    }, retried === true)
+    }
+    handle.job = job
+    if (timeoutMs > 0) timedJobs = timedJobs.concat([job])
+    return enqueueJob(job)
   }
 
   function cancelSearch() {
@@ -190,6 +285,10 @@ Item {
       if (typeof callback !== "function") return
       if (error) callback(Api.searchGroups({}, 128), error)
       else callback(Api.searchGroups(payload, 128), "")
+    }, {
+      priority: "interactive",
+      timeoutMs: Api.SEARCH_REQUEST_TIMEOUT_MS,
+      retryRateLimit: false
     })
   }
 
@@ -197,5 +296,12 @@ Item {
     id: rateLimitTimer
     repeat: false
     onTriggered: root.pumpRequests()
+  }
+
+  Timer {
+    interval: 250
+    repeat: true
+    running: root.timedJobs.length > 0
+    onTriggered: root.expireTimedOutRequests(root.now())
   }
 }

--- a/tests/tst_api.qml
+++ b/tests/tst_api.qml
@@ -203,6 +203,7 @@ TestCase {
     compare(Api.displayedSliderVolume(0.5, pending, 9000), 0.5)
     verify(!Api.pendingSliderVolumeShouldHold(0.5, null, 2000))
     compare(Api.SEARCH_DEBOUNCE_MS, 600)
+    compare(Api.SEARCH_REQUEST_TIMEOUT_MS, 8000)
     compare(Api.VOLUME_FLUSH_MS, 80)
   }
 
@@ -252,9 +253,22 @@ TestCase {
     verify(!Api.apiRequestIsMutating("GET"))
     var queued = Api.enqueueApiJob([], { method: "GET", id: "one" })
     queued = Api.enqueueApiJob(queued, { method: "GET", id: "two" })
+    queued = Api.enqueueApiJob(queued,
+      { method: "GET", id: "search", priority: "interactive" })
     queued = Api.enqueueApiJob(queued, { method: "PUT", id: "play" })
     compare(queued[0].id, "play")
-    compare(queued[1].id, "one")
+    compare(queued[1].id, "search")
+    compare(queued[2].id, "one")
+    compare(queued[3].id, "two")
+    compare(Api.apiJobPriority(queued[0]), 2)
+    compare(Api.apiJobPriority(queued[1]), 1)
+    compare(Api.apiJobPriority(queued[2]), 0)
+    queued = Api.enqueueApiJob(queued,
+      { method: "GET", id: "search-two", priority: "interactive" })
+    queued = Api.enqueueApiJob(queued, { method: "POST", id: "pause" })
+    compare(queued[1].id, "pause")
+    compare(queued[2].id, "search")
+    compare(queued[3].id, "search-two")
     var skipped = Api.dequeueApiJob([
       { id: "stale", handle: { aborted: true } },
       { id: "live", handle: { aborted: false } }

--- a/tests/tst_spotify_api.qml
+++ b/tests/tst_spotify_api.qml
@@ -1,0 +1,318 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtTest
+
+import ".." as Plugin
+
+TestCase {
+  id: testCase
+  name: "SpotifyApiTransport"
+
+  property var requests: []
+  property double clock: 1000
+  property int tokenInvalidations: 0
+  property string accessToken: "mock-token"
+  property string accessTokenError: ""
+  property bool failFactory: false
+  property bool failOpen: false
+  property bool failSend: false
+
+  QtObject {
+    id: fakeAuth
+
+    function withAccessToken(callback) {
+      callback(testCase.accessToken, testCase.accessTokenError)
+    }
+    function invalidateAccessToken() { testCase.tokenInvalidations++ }
+  }
+
+  Component {
+    id: apiComponent
+
+    Plugin.SpotifyApi {
+      auth: fakeAuth
+      now: function() { return testCase.clock }
+      xhrFactory: function() {
+        if (testCase.failFactory) throw new Error("factory failed")
+        return testCase.newRequest()
+      }
+    }
+  }
+
+  function newRequest() {
+    var xhr = {
+      readyState: XMLHttpRequest.UNSENT,
+      status: 0,
+      responseText: "",
+      url: "",
+      method: "",
+      aborted: false,
+      onreadystatechange: null,
+      open: function(method, url) {
+        if (testCase.failOpen) throw new Error("open failed")
+        this.method = method
+        this.url = url
+        this.readyState = XMLHttpRequest.OPENED
+      },
+      setRequestHeader: function() {},
+      getResponseHeader: function(name) {
+        return String(name).toLowerCase() === "retry-after" ? "1" : ""
+      },
+      send: function() {
+        if (testCase.failSend) throw new Error("send failed")
+      },
+      abort: function() { this.aborted = true }
+    }
+    requests.push(xhr)
+    return xhr
+  }
+
+  function complete(xhr, status, body) {
+    xhr.status = status
+    xhr.responseText = body || "{}"
+    xhr.readyState = XMLHttpRequest.DONE
+    xhr.onreadystatechange()
+  }
+
+  function init() {
+    requests = []
+    clock = 1000
+    tokenInvalidations = 0
+    accessToken = "mock-token"
+    accessTokenError = ""
+    failFactory = false
+    failOpen = false
+    failSend = false
+  }
+
+  function test_priorityStartsMutationsThenInteractiveReads() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    api.request("GET", "/me", null, null, function() {})
+    api.request("GET", "/me/player", null, null, function() {})
+    api.request("GET", "/me/albums", null, null, function() {})
+    api.request("GET", "/search", null, null, function() {},
+      { priority: "interactive" })
+    api.request("PUT", "/me/player/play", null, null, function() {})
+    compare(requests.length, 2)
+
+    complete(requests[0], 200)
+    compare(requests.length, 3)
+    compare(requests[2].method, "PUT")
+
+    complete(requests[1], 200)
+    compare(requests.length, 4)
+    verify(requests[3].url.indexOf("/search") >= 0)
+  }
+
+  function test_searchKeepsTheExistingAllTypesRequest() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var callbacks = 0
+    api.search("miles davis", function(groups, error) {
+      callbacks++
+      compare(error, "")
+    })
+    compare(requests.length, 1)
+    verify(decodeURIComponent(requests[0].url).indexOf(
+      "type=track,artist,album,playlist,show,episode,audiobook") >= 0)
+    complete(requests[0], 200, "{\"tracks\":{\"items\":[]}}")
+    compare(callbacks, 1)
+  }
+
+  function test_searchTimeoutAbortsAndReleasesSlotOnce() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var callbacks = 0
+    var error = ""
+    api.search("stalled", function(groups, reason) {
+      callbacks++
+      error = reason
+    })
+    compare(api.requestsInFlight, 1)
+    clock = 9000
+    api.expireTimedOutRequests(clock)
+    verify(requests[0].aborted)
+    verify(error.indexOf("too long") >= 0)
+    compare(callbacks, 1)
+    compare(api.requestsInFlight, 0)
+    compare(api.timedJobs.length, 0)
+
+    complete(requests[0], 0)
+    compare(callbacks, 1)
+    compare(api.requestsInFlight, 0)
+  }
+
+  function test_queuedSearchTimesOutBeforeARequestSlotOpens() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    api.request("GET", "/me", null, null, function() {})
+    api.request("GET", "/me/player", null, null, function() {})
+    compare(api.requestsInFlight, 2)
+    var error = ""
+    api.search("queued", function(groups, reason) { error = reason })
+    compare(requests.length, 2)
+    compare(api.requestQueue.length, 1)
+    clock = 9000
+    api.expireTimedOutRequests(clock)
+    verify(error.indexOf("too long") >= 0)
+    compare(api.requestQueue.length, 0)
+    compare(api.requestsInFlight, 2)
+  }
+
+  function test_search429ReturnsWithoutSilentRetry() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var callbacks = 0
+    var error = ""
+    api.search("busy", function(groups, reason) {
+      callbacks++
+      error = reason
+    })
+    complete(requests[0], 429, "{\"error\":{\"message\":\"Too many requests\"}}")
+    compare(callbacks, 1)
+    verify(error.indexOf("Spotify is busy") >= 0)
+    compare(api.requestQueue.length, 0)
+    compare(api.requestsInFlight, 0)
+    verify(api.rateLimitedUntil > clock)
+  }
+
+  function test_default429StillRetriesAfterCooldown() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var callbacks = 0
+    api.request("GET", "/me", null, null, function() { callbacks++ })
+    complete(requests[0], 429)
+    compare(callbacks, 0)
+    compare(api.requestQueue.length, 1)
+    clock = api.rateLimitedUntil
+    api.pumpRequests()
+    compare(requests.length, 2)
+    complete(requests[1], 200)
+    compare(callbacks, 1)
+  }
+
+  function test_401RetriesWithOneTokenInvalidation() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var callbacks = 0
+    api.request("GET", "/me", null, null, function() { callbacks++ })
+    var firstRequest = requests[0]
+    complete(requests[0], 401)
+    compare(tokenInvalidations, 1)
+    compare(callbacks, 0)
+    compare(requests.length, 2)
+    complete(firstRequest, 200)
+    compare(callbacks, 0)
+    complete(requests[1], 200)
+    compare(callbacks, 1)
+  }
+
+  function test_newSearchCancelsStaleActiveRequest() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var staleCalls = 0
+    var currentCalls = 0
+    api.search("old", function() { staleCalls++ })
+    var oldRequest = requests[0]
+    api.search("new", function() { currentCalls++ })
+    verify(oldRequest.aborted)
+    compare(requests.length, 2)
+    complete(oldRequest, 200, "{\"tracks\":{\"items\":[]}}")
+    complete(requests[1], 200, "{\"tracks\":{\"items\":[]}}")
+    compare(staleCalls, 0)
+    compare(currentCalls, 1)
+    compare(api.requestsInFlight, 0)
+  }
+
+  function test_cancelledQueuedRequestNeverStarts() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    api.request("GET", "/me", null, null, function() {})
+    api.request("GET", "/me/player", null, null, function() {})
+    var callbacks = 0
+    var handle = api.request("GET", "/search", null, null,
+      function() { callbacks++ }, {
+        priority: "interactive",
+        timeoutMs: 8000
+      })
+    compare(api.requestQueue.length, 1)
+    api.abortRequest(handle)
+    compare(api.requestQueue.length, 0)
+    complete(requests[0], 200)
+    compare(requests.length, 2)
+    compare(callbacks, 0)
+    compare(api.timedJobs.length, 0)
+  }
+
+  function test_timeoutUsesInclusiveDeadlineBoundary() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var callbacks = 0
+    api.request("GET", "/search", null, null, function() { callbacks++ },
+      { timeoutMs: 1000 })
+    api.expireTimedOutRequests(1999)
+    compare(callbacks, 0)
+    verify(!requests[0].aborted)
+    clock = 2000
+    api.expireTimedOutRequests(clock)
+    compare(callbacks, 1)
+    verify(requests[0].aborted)
+  }
+
+  function test_queuedRateLimitRetryCanTimeOutDuringCooldown() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var callbacks = 0
+    var error = ""
+    api.request("GET", "/me", null, null, function(status, payload, reason) {
+      callbacks++
+      error = reason
+    }, { timeoutMs: 2000 })
+    complete(requests[0], 429)
+    compare(api.requestQueue.length, 1)
+    clock = 3000
+    api.expireTimedOutRequests(clock)
+    compare(callbacks, 1)
+    verify(error.indexOf("too long") >= 0)
+    compare(api.requestQueue.length, 0)
+  }
+
+  function test_invalidUrlAndTokenFailureReleaseSlots() {
+    var api = createTemporaryObject(apiComponent, testCase)
+    verify(api)
+    var errors = 0
+    api.request("GET", "https://example.com/not-spotify", null, null,
+      function(status, payload, error) { if (error) errors++ })
+    compare(errors, 1)
+    compare(api.requestsInFlight, 0)
+
+    accessToken = ""
+    accessTokenError = "Session unavailable"
+    api.request("GET", "/me", null, null,
+      function(status, payload, error) { if (error) errors++ })
+    compare(errors, 2)
+    compare(api.requestsInFlight, 0)
+  }
+
+  function test_xhrSetupFailuresReleaseSlots() {
+    var modes = ["factory", "open", "send"]
+    for (var i = 0; i < modes.length; i++) {
+      failFactory = modes[i] === "factory"
+      failOpen = modes[i] === "open"
+      failSend = modes[i] === "send"
+      var api = createTemporaryObject(apiComponent, testCase)
+      verify(api)
+      var callbacks = 0
+      api.request("GET", "/me", null, null,
+        function(status, payload, error) {
+          callbacks++
+          verify(error !== "")
+        })
+      compare(callbacks, 1)
+      compare(api.requestsInFlight, 0)
+      api.destroy()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- prioritize mutations, interactive reads, and background reads while preserving FIFO order within each class
- make queued and active cancellation/timeout paths terminal, idempotent, and slot-safe
- keep the existing all-result search request and navigation unchanged while adding an 8-second end-to-end timeout
- return search rate limits immediately, while retaining bounded cooldown retries for ordinary API requests
- ignore late responses from superseded 401/429 attempts and handle synchronous XHR setup failures

This is split 1 of 4 from #22, following the review request. It contains only transport behavior and its dedicated tests; per-result-type search, UI/navigation changes, and automatic pagination are intentionally excluded.

## Tests

- ./scripts/test.sh — 140 QML tests plus backend, Python, and script validation passed
- tests/tst_spotify_api.qml covers priority/FIFO behavior, active and queued timeout paths, cancellation races, 401/429 retries, invalid URL/token handling, and XHR factory/open/send failures