### PR TITLE
Resolve the plugin directory from the component URL

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -22,8 +22,8 @@ Item {
 
   readonly property string pluginId: manifest && manifest.id
     ? String(manifest.id) : "quickshell.spotify"
-  readonly property string pluginDir: manifest && manifest.__sourceDir
-    ? String(manifest.__sourceDir) : ""
+  readonly property string pluginDir: String(Qt.resolvedUrl("."))
+    .replace(/^file:\/\//, "").replace(/\/$/, "")
   readonly property string homeDirectory: Quickshell.env("HOME") || ""
   readonly property string stateHome: {
     var explicit = String(Quickshell.env("XDG_STATE_HOME") || "").trim()


### PR DESCRIPTION
On Omarchy 4.0.3 local playback cannot start.

4.0.3 added `publicPluginManifest()` in `shell.qml`. It deletes `__sourceDir` from the manifest handed to third-party plugin surfaces. 4.0.2 passed the manifest through as it was.

So `pluginDir` is `""`, and every path call in `DaemonManager.qml` guards on it and returns early: the requirement probes, the credentials probe, the config writer, the setup wrapper.

Settings sits on "Checking playback support..." and "Checking local playback...". Play reports "Approve playback on this computer in Settings, then try again", while the backend binary, the systemd unit and the saved credentials are all present and valid.

`Qt.resolvedUrl(".")` resolves against this component, so it works whatever the host publishes.

I checked it by logging the probe scripts across a shell restart. None ran before the change, all three ran after.

CI pins Omarchy at `97a86af`, which is older than the sanitiser, so the validation job could not have caught this.
