### PR TITLE
Add a local playback output selector

### DIFF
--- a/Api.js
+++ b/Api.js
@@ -402,6 +402,12 @@ function normalizedShortcutHints(value) {
   return String(value || "On") === "Off" ? "Off" : "On"
 }
 
+function hasSettingValues(values) {
+  if (!values || typeof values !== "object") return false
+  for (var key in values) return true
+  return false
+}
+
 function shortcutSequenceList(value) {
   if (value === undefined || value === null || value === "") return []
   return Array.isArray(value) ? value : [value]

--- a/Api.js
+++ b/Api.js
@@ -408,6 +408,14 @@ function hasSettingValues(values) {
   return false
 }
 
+function normalizedAudioDevice(value) {
+  var device = String(value === undefined || value === null ? "" : value).trim()
+  if (device.length > 128) return ""
+  if (/["\\]/.test(device)) return ""
+  if (/[^\x20-\x7e]/.test(device)) return ""
+  return device
+}
+
 function shortcutSequenceList(value) {
   if (value === undefined || value === null || value === "") return []
   return Array.isArray(value) ? value : [value]

--- a/DaemonManager.qml
+++ b/DaemonManager.qml
@@ -17,6 +17,8 @@ Item {
   property string pluginDir: ""
   property string deviceName: "Omarchy Spotify"
   property int bitrateKbps: 320
+  property string audioDevice: ""
+  property var audioSinks: []
   property string unitName: "omarchy-spotify.service"
   property bool authenticationCancelled: false
   property bool mprisPresent: false
@@ -77,6 +79,7 @@ Item {
       unitCheck.running = true
     }
     checkCredentials()
+    refreshAudioSinks()
     requestConfiguration()
   }
 
@@ -98,6 +101,12 @@ Item {
     setupBusy = true
     setupCommand.command = [pluginDir + "/scripts/setup-playback.sh"]
     setupCommand.running = true
+  }
+
+  function refreshAudioSinks() {
+    if (!pluginDir || sinkList.running) return
+    sinkList.command = ["/usr/bin/bash", pluginDir + "/scripts/list-audio-sinks.sh"]
+    sinkList.running = true
   }
 
   function requestConfiguration() {
@@ -155,9 +164,10 @@ Item {
       return
     }
     configurationPending = false
-    // The blank third line explicitly clears any legacy per-app sink choice.
-    // Omarchy's Audio panel remains the sole owner of desktop audio routing.
-    configurationInput = String(deviceName) + "\n" + String(bitrateKbps) + "\n"
+    // The third line names the PulseAudio sink librespot opens. Blank leaves
+    // the key out, so playback follows Omarchy's system default output.
+    configurationInput = String(deviceName) + "\n" + String(bitrateKbps)
+      + "\n" + String(audioDevice) + "\n"
     configurationBusy = true
     configWriter.command = [pluginDir + "/scripts/configure-spotifyd.sh"]
     configWriter.running = true
@@ -233,6 +243,7 @@ Item {
 
   onDeviceNameChanged: requestConfiguration()
   onBitrateKbpsChanged: requestConfiguration()
+  onAudioDeviceChanged: requestConfiguration()
   onPluginDirChanged: {
     if (!pluginDir) return
     checkRequirements()
@@ -366,6 +377,27 @@ Item {
         root.terminalFailure = true
         root.lastError = messages[code]
       }
+    }
+  }
+
+  Process {
+    id: sinkList
+    stdout: StdioCollector { id: sinkListOutput; waitForEnd: true }
+    stderr: StdioCollector { waitForEnd: true }
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        root.audioSinks = []
+        return
+      }
+      var rows = []
+      var lines = String(sinkListOutput.text || "").split("\n")
+      for (var i = 0; i < lines.length; i++) {
+        var parts = lines[i].split("\t")
+        var name = Api.normalizedAudioDevice(parts[0])
+        if (!name) continue
+        rows.push({ name: name, description: String(parts[1] || "").trim() || name })
+      }
+      root.audioSinks = rows
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -84,6 +84,7 @@ Item {
   // Disclosure state for the width slider; deliberately not persisted.
   property bool barTextWidthExpanded: false
   property string draftAudioQuality: "320 kbps"
+  property string draftAudioDevice: ""
   property var contextItem: null
   property var contextSourceItems: []
   property string contextSourceUri: ""
@@ -212,6 +213,7 @@ Item {
     draftMaxBarTextWidth = service.maxBarTextWidth
     draftFixedBarWidth = service.fixedBarWidth
     draftAudioQuality = service.audioQuality
+    draftAudioDevice = service.audioDevice
   }
 
   function saveSettings(showStatus) {
@@ -233,7 +235,8 @@ Item {
       scrollSpeed: Api.normalizedScrollSpeed(draftScrollSpeed),
       maxBarTextWidth: Api.normalizedMaxBarTextWidth(draftMaxBarTextWidth),
       fixedBarWidth: draftFixedBarWidth ? "On" : "Off",
-      audioQuality: draftAudioQuality
+      audioQuality: draftAudioQuality,
+      audioDevice: draftAudioDevice
     }
     service.persistSettings(values)
     syncDraftSettings()
@@ -256,6 +259,20 @@ Item {
       : (draftShortcutPlayer === "Full player"
         ? "Mini player" : "Omarchy Music app")
     persistDraftSettings()
+  }
+
+  function audioDeviceLabel() {
+    if (!draftAudioDevice) return "System default"
+    var sinks = root.service ? root.service.daemon.audioSinks : []
+    for (var i = 0; i < sinks.length; i++)
+      if (sinks[i].name === draftAudioDevice) return sinks[i].description
+    return draftAudioDevice
+  }
+
+  function selectAudioDevice(name) {
+    draftAudioDevice = Api.normalizedAudioDevice(name)
+    persistDraftSettings()
+    audioDevicePicker.close()
   }
 
   function audioQualityLabel() {
@@ -2731,6 +2748,99 @@ Item {
         }
       }
         }
+      }
+    }
+  }
+
+  Popup {
+    id: audioDevicePicker
+    parent: window.contentItem
+    x: Math.max(Style.space(8), (window.width - width) / 2)
+    y: Math.max(Style.space(8), (window.height - height) / 2)
+    width: Math.min(Style.space(410), window.width - Style.space(32))
+    height: Math.min(Style.space(520), audioDeviceContent.implicitHeight + padding * 2)
+    padding: Style.space(8)
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    background: BorderSurface {
+      color: root.popupBackground
+      radius: Style.cornerRadius
+      borderSpec: root.popupBorderSpec
+    }
+
+    contentItem: Column {
+      id: audioDeviceContent
+      spacing: Style.space(7)
+
+      Text {
+        width: parent.width
+        text: "Local playback output"
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.subtitle
+        font.bold: true
+        elide: Text.ElideRight
+      }
+
+      Text {
+        width: parent.width
+        text: "Send this computer's playback to one output instead of following the system default. Takes effect the next time local playback starts."
+        color: root.muted
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        wrapMode: Text.WordWrap
+      }
+
+      PanelSeparator { width: parent.width; foreground: root.foreground }
+
+      Button {
+        width: parent.width
+        text: "System default"
+        iconText: root.draftAudioDevice ? "󰄰" : "󰄯"
+        foreground: root.foreground
+        leftAlign: true
+        onClicked: root.selectAudioDevice("")
+      }
+
+      ListView {
+        id: audioDeviceList
+        width: parent.width
+        height: Math.min(Style.space(300), Math.max(Style.space(40), contentHeight))
+        model: root.service ? root.service.daemon.audioSinks : []
+        clip: true
+        spacing: Style.space(2)
+        keyNavigationEnabled: true
+        highlightFollowsCurrentItem: true
+        activeFocusOnTab: true
+        ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+        Keys.onReturnPressed: if (currentItem) currentItem.clicked()
+        Keys.onEnterPressed: if (currentItem) currentItem.clicked()
+
+        FastScrollHandler { parent: audioDeviceList; flickable: audioDeviceList }
+
+        delegate: Button {
+          required property var modelData
+          width: Math.max(80, ListView.view.width
+            - (audioDeviceList.contentHeight > audioDeviceList.height
+              ? root.popupScrollbarGutter : 0))
+          text: modelData.description
+          iconText: root.draftAudioDevice === modelData.name ? "󰄯" : "󰄰"
+          foreground: root.foreground
+          leftAlign: true
+          onClicked: root.selectAudioDevice(modelData.name)
+        }
+      }
+
+      Text {
+        width: parent.width
+        visible: audioDeviceList.count === 0
+        text: "No audio outputs were found on this computer."
+        color: root.muted
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        wrapMode: Text.WordWrap
       }
     }
   }
@@ -6993,6 +7103,17 @@ Item {
                 foreground: root.foreground
                 tooltipText: "Change streaming quality"
                 onClicked: root.cycleAudioQuality()
+              }
+
+              Button {
+                text: "Output · " + root.audioDeviceLabel()
+                iconText: "󰓃"
+                foreground: root.foreground
+                tooltipText: "Choose where local playback sends audio"
+                onClicked: {
+                  if (root.service) root.service.daemon.refreshAudioSinks()
+                  audioDevicePicker.open()
+                }
               }
             }
 

--- a/Service.qml
+++ b/Service.qml
@@ -82,6 +82,7 @@ Item {
       : (quality.indexOf("160") === 0 ? 160 : 320)
   }
   readonly property string audioQuality: bitrateKbps + " kbps"
+  readonly property string audioDevice: String(settings.audioDevice || "")
   property var searchHistory: []
   property var sessionState: ({})
   property bool sessionFileReady: false
@@ -497,7 +498,7 @@ Item {
     var keys = ["deviceName", "idleShutdownMinutes", "showMiniPlayer",
       "showVinylRecord", "shortcutPlayer", "shortcutHints", "showLyrics", "showArtwork", "showTrackTitle", "showArtistName",
       "showPausedTrack", "scrollBarText", "scrollSpeed", "maxBarTextWidth",
-      "fixedBarWidth", "audioQuality", "clientId"]
+      "fixedBarWidth", "audioQuality", "audioDevice", "clientId"]
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i]
       if (source[key] !== undefined) next[key] = source[key]
@@ -526,6 +527,7 @@ Item {
     var quality = String(next.audioQuality || "320 kbps")
     next.audioQuality = quality.indexOf("96") === 0 ? "96 kbps"
       : (quality.indexOf("160") === 0 ? "160 kbps" : "320 kbps")
+    next.audioDevice = Api.normalizedAudioDevice(next.audioDevice)
     // A personal Spotify client ID opts out of the shared rate-limit bucket.
     // Anything that is not a 32-hex ID (including empty) means "keep shipped".
     var customClientId = String(next.clientId || "").trim()
@@ -4169,6 +4171,7 @@ Item {
     pluginDir: root.pluginDir
     deviceName: root.deviceName
     bitrateKbps: root.bitrateKbps
+    audioDevice: root.audioDevice
     mprisPresent: root.hasLocalPlayer
   }
 

--- a/Service.qml
+++ b/Service.qml
@@ -22,8 +22,8 @@ Item {
 
   readonly property string pluginId: manifest && manifest.id
     ? String(manifest.id) : "quickshell.spotify"
-  readonly property string pluginDir: manifest && manifest.__sourceDir
-    ? String(manifest.__sourceDir) : ""
+  readonly property string pluginDir: String(Qt.resolvedUrl("."))
+    .replace(/^file:\/\//, "").replace(/\/$/, "")
   readonly property string homeDirectory: Quickshell.env("HOME") || ""
   readonly property string stateHome: {
     var explicit = String(Quickshell.env("XDG_STATE_HOME") || "").trim()

--- a/Service.qml
+++ b/Service.qml
@@ -554,6 +554,10 @@ Item {
   }
 
   function applySettings(values) {
+    // A bar widget pushes its settings before the host hands it the layout
+    // entry. On a second monitor that empty push lands after the real one,
+    // and applying it would reset every stored setting to its default.
+    if (!Api.hasSettingValues(values)) return
     var previousDeviceName = deviceName
     var next = normalizedSettings(values)
     if (JSON.stringify(next) !== JSON.stringify(settings)) settings = next

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -182,4 +182,37 @@ mod tests {
         fs::remove_file(path).unwrap();
         fs::remove_dir(dir).unwrap();
     }
+
+    #[test]
+    fn reads_the_selected_output_sink() {
+        let dir = std::env::temp_dir().join(format!(
+            "omarchy-spotify-device-test-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("spotifyd.conf");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            "[global]\ndevice_name=\"Test Device\"\nbackend=\"pulseaudio\"\ndevice=\"alsa_output.usb-Mini__Line2__sink\""
+        )
+        .unwrap();
+
+        let config = BackendConfig::load(&path).unwrap();
+        assert_eq!(
+            config.audio_device.as_deref(),
+            Some("alsa_output.usb-Mini__Line2__sink")
+        );
+
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            "[global]\ndevice_name=\"Test Device\"\nbackend=\"pulseaudio\"\ndevice=\"   \""
+        )
+        .unwrap();
+        assert_eq!(BackendConfig::load(&path).unwrap().audio_device, None);
+
+        fs::remove_file(path).unwrap();
+        fs::remove_dir(dir).unwrap();
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.4",
   "author": "QuickshellSpotify",
   "license": "MIT",
-  "description": "Spotify in Quickshell with all the features you need\u2014using about 60 MB of memory versus roughly 950 MB for the official client.",
+  "description": "Spotify in Quickshell with all the features you need—using about 60 MB of memory versus roughly 950 MB for the official client.",
   "kinds": [
     "service",
     "bar-widget",
@@ -19,7 +19,7 @@
   },
   "barWidget": {
     "displayName": "Omarchy Spotify",
-    "description": "Spotify in Quickshell with all the features you need\u2014using about 60 MB of memory versus roughly 950 MB for the official client.",
+    "description": "Spotify in Quickshell with all the features you need—using about 60 MB of memory versus roughly 950 MB for the official client.",
     "category": "Media",
     "aliases": [
       "spotify",
@@ -44,6 +44,7 @@
       "maxBarTextWidth": "240",
       "fixedBarWidth": "Off",
       "audioQuality": "320 kbps",
+      "audioDevice": "",
       "showArtwork": "On",
       "clientId": ""
     },
@@ -200,6 +201,13 @@
         ],
         "defaultValue": "320 kbps",
         "description": "Takes effect the next time playback starts."
+      },
+      {
+        "key": "audioDevice",
+        "type": "string",
+        "label": "Local playback output",
+        "defaultValue": "",
+        "description": "PulseAudio sink that local playback opens. Empty follows the system default. Choose it from the player's Settings; it takes effect the next time playback starts."
       },
       {
         "key": "showArtwork",

--- a/scripts/configure-spotifyd.sh
+++ b/scripts/configure-spotifyd.sh
@@ -10,6 +10,8 @@ bitrate_specified=0
 if IFS= read -r bitrate; then
   bitrate_specified=1
 fi
+device=""
+IFS= read -r device || true
 
 if [[ -z $device_name || ${#device_name} -gt 64 || $device_name == *'"'* || $device_name == *'\'* ]]; then
   exit 3
@@ -20,6 +22,12 @@ fi
 if (( bitrate_specified )) && [[ $bitrate != 96 && $bitrate != 160 && $bitrate != 320 ]]; then
   exit 3
 fi
+if [[ ${#device} -gt 128 || $device == *'"'* || $device == *'\'* ]]; then
+  exit 3
+fi
+if [[ -n $device && $device =~ [^[:print:]] ]]; then
+  exit 3
+fi
 if [[ ! -f $config_file ]]; then
   exit 4
 fi
@@ -28,7 +36,7 @@ temporary=$(mktemp "${config_file}.tmp.XXXXXX")
 trap 'rm -f -- "$temporary"' EXIT
 chmod 600 "$temporary"
 
-awk -v name="$device_name" -v rate="$bitrate" -v rate_set="$bitrate_specified" '
+awk -v name="$device_name" -v rate="$bitrate" -v rate_set="$bitrate_specified" -v device="$device" '
   /^device_name[[:space:]]*=/ {
     print "device_name = \"" name "\""
     found_name = 1
@@ -41,7 +49,8 @@ awk -v name="$device_name" -v rate="$bitrate" -v rate_set="$bitrate_specified" '
     next
   }
   /^device[[:space:]]*=/ {
-    next
+    if (!found_device && device != "") print "device = \"" device "\""
+    found_device = 1
     next
   }
   /^autoplay[[:space:]]*=/ {
@@ -53,6 +62,7 @@ awk -v name="$device_name" -v rate="$bitrate" -v rate_set="$bitrate_specified" '
   END {
     if (!found_name) print "device_name = \"" name "\""
     if (!found_rate && rate_set) print "bitrate = " rate
+    if (!found_device && device != "") print "device = \"" device "\""
     if (!found_autoplay) print "autoplay = true"
   }
 ' "$config_file" >"$temporary"

--- a/scripts/list-audio-sinks.sh
+++ b/scripts/list-audio-sinks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One tab-separated sink name and description per line, for the Settings
+# output picker. The name is what librespot opens; the description is shown.
+pactl -f json list sinks | jq -r '.[] | [.name, .description] | @tsv'

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -165,6 +165,62 @@ invalid_status=$?
 set -e
 [[ $invalid_status -eq 3 ]]
 
+# A third input line selects the PulseAudio sink librespot opens. An empty
+# line restores the system default by dropping the key entirely.
+printf '%s\n%s\n%s\n' "Desk speakers" 320 "alsa_output.usb-Mini__Line2__sink" |
+  XDG_CONFIG_HOME="$test_root/config" "$source_root/scripts/configure-spotifyd.sh"
+grep -qx 'device = "alsa_output.usb-Mini__Line2__sink"' "$test_root/config/omarchy-spotify/spotifyd.conf"
+grep -qx 'device_name = "Desk speakers"' "$test_root/config/omarchy-spotify/spotifyd.conf"
+[[ $(grep -c '^device[[:space:]]*=' "$test_root/config/omarchy-spotify/spotifyd.conf") -eq 1 ]]
+
+printf '%s\n%s\n%s\n' "Desk speakers" 320 "alsa_output.usb-Mini__Line3__sink" |
+  XDG_CONFIG_HOME="$test_root/config" "$source_root/scripts/configure-spotifyd.sh"
+grep -qx 'device = "alsa_output.usb-Mini__Line3__sink"' "$test_root/config/omarchy-spotify/spotifyd.conf"
+[[ $(grep -c '^device[[:space:]]*=' "$test_root/config/omarchy-spotify/spotifyd.conf") -eq 1 ]]
+
+printf '%s\n%s\n\n' "Desk speakers" 320 |
+  XDG_CONFIG_HOME="$test_root/config" "$source_root/scripts/configure-spotifyd.sh"
+! grep -q '^device[[:space:]]*=' "$test_root/config/omarchy-spotify/spotifyd.conf"
+
+set +e
+printf '%s\n%s\n%s\n' "Desk speakers" 320 'invalid"sink' |
+  XDG_CONFIG_HOME="$test_root/config" "$source_root/scripts/configure-spotifyd.sh"
+invalid_device_status=$?
+set -e
+[[ $invalid_device_status -eq 3 ]]
+! grep -q 'invalid' "$test_root/config/omarchy-spotify/spotifyd.conf"
+
+# The sink list feeds the Settings picker: one tab-separated name and
+# description per sink, and a non-zero exit when PulseAudio is unreachable.
+sink_mock_bin="$test_root/sink-mock-bin"
+mkdir -p "$sink_mock_bin"
+cat >"$sink_mock_bin/pactl" <<'MOCK'
+#!/usr/bin/env bash
+[[ $* == "-f json list sinks" ]] || exit 64
+cat <<'JSON'
+[
+  {"index": 60, "name": "alsa_output.usb-Mini__Line2__sink", "description": "GoXLR Mini Line 2"},
+  {"index": 63, "name": "alsa_output.pci-0000_00_1f.3.analog-stereo", "description": "Built-in Audio"}
+]
+JSON
+MOCK
+chmod +x "$sink_mock_bin/pactl"
+sink_output=$(PATH="$sink_mock_bin:$PATH" "$source_root/scripts/list-audio-sinks.sh")
+[[ $sink_output == "alsa_output.usb-Mini__Line2__sink	GoXLR Mini Line 2
+alsa_output.pci-0000_00_1f.3.analog-stereo	Built-in Audio" ]]
+
+cat >"$sink_mock_bin/pactl" <<'MOCK'
+#!/usr/bin/env bash
+echo "Connection failure: Connection refused" >&2
+exit 1
+MOCK
+chmod +x "$sink_mock_bin/pactl"
+set +e
+PATH="$sink_mock_bin:$PATH" "$source_root/scripts/list-audio-sinks.sh" >/dev/null 2>&1
+sink_failure_status=$?
+set -e
+[[ $sink_failure_status -ne 0 ]]
+
 # Exercise setup and removal entirely inside the temporary tree. The mock
 # spotifyd/systemctl binaries prevent package, service, keyring, or user-config
 # changes while still covering the scripts' real file permissions and paths.

--- a/tests/tst_api.qml
+++ b/tests/tst_api.qml
@@ -95,6 +95,17 @@ TestCase {
     compare(Api.normalizedScrollSpeed(1.13), 1.25)
   }
 
+  // A bar widget pushes its settings before the host hands it the layout
+  // entry. Treating that empty push as real resets every stored setting to
+  // its default, and on a second monitor it arrives after the real one.
+  function test_hasSettingValues_ignoresAnEmptyPush() {
+    compare(Api.hasSettingValues(undefined), false)
+    compare(Api.hasSettingValues(null), false)
+    compare(Api.hasSettingValues({}), false)
+    compare(Api.hasSettingValues({ deviceName: "Desk" }), true)
+    compare(Api.hasSettingValues({ clientId: "" }), true)
+  }
+
   function test_cacheFreshnessAndSleepDeadline_boundaries() {
     verify(Api.timestampIsFresh(1000, 5999, 5000))
     verify(!Api.timestampIsFresh(1000, 6000, 5000))

--- a/tests/tst_api.qml
+++ b/tests/tst_api.qml
@@ -95,6 +95,19 @@ TestCase {
     compare(Api.normalizedScrollSpeed(1.13), 1.25)
   }
 
+  // An unusable sink name must fall back to the system default rather than
+  // reaching configure-spotifyd.sh, which rejects the write outright.
+  function test_normalizedAudioDevice_trimsAndRejectsUnusableNames() {
+    compare(Api.normalizedAudioDevice(undefined), "")
+    compare(Api.normalizedAudioDevice("  alsa_output.usb-Mini__Line2__sink  "),
+      "alsa_output.usb-Mini__Line2__sink")
+    compare(Api.normalizedAudioDevice('sink"name'), "")
+    compare(Api.normalizedAudioDevice("sink\\name"), "")
+    compare(Api.normalizedAudioDevice("sink\tname"), "")
+    compare(Api.normalizedAudioDevice(new Array(130).join("a")), "")
+    compare(Api.normalizedAudioDevice(new Array(129).join("a")).length, 128)
+  }
+
   // A bar widget pushes its settings before the host hands it the layout
   // entry. Treating that empty push as real resets every stored setting to
   // its default, and on a second monitor it arrives after the real one.


### PR DESCRIPTION
Send local playback to one output instead of the system default.

![Output row](https://raw.githubusercontent.com/pontino/Omarchy-Spotify/assets/issue-76/issue-76/02-row.png)

![Output picker](https://raw.githubusercontent.com/pontino/Omarchy-Spotify/assets/issue-76/issue-76/03-picker.png)

`backend/src/config.rs` already reads `device` from `[global]` and passes it to librespot's PulseAudio sink. Nothing could set it, because the awk in `configure-spotifyd.sh` deleted that line on every write.

Empty is the default and writes no `device` key, so nothing changes unless someone picks an output. Once picked, the setting lives in `shell.json` and survives updates.

The Audio panel sets the system default. It cannot send one app to one channel of a mixer, and that is what a GoXLR or a Scarlett is for. PulseAudio has always allowed it per stream. The only way today is a `PULSE_SINK` systemd drop-in, which the app cannot see.

What is here:

- `audioDevice` setting, empty by default.
- `scripts/list-audio-sinks.sh`, reads sinks from `pactl -f json` with `jq`. The validation workflow already installs both. If it fails the picker offers System default only.
- Output row under PLAYBACK opening a picker built like the playlist picker. Sinks listed by description, stored by name, refreshed on load and each time the picker opens.
- Sink name checked like the Connect device name. Applies the next time local playback starts, like audio quality.

Two supporting commits:

- `pluginDir` now comes from `Qt.resolvedUrl(".")`. The helper scripts are launched by path, so the path should not depend on what the host puts in the manifest.
- A bar widget sends its settings before the host gives it the layout entry, so the service gets `{}` and `normalizedSettings()` refills it from the defaults. With two monitors that empty push lands after the real one and wipes the stored value. Existing settings hide it because writing a default over a default looks the same. Happy to split this one out if you prefer.

`scripts/test.sh` passes.
